### PR TITLE
Setup Istanbul and Coveralls for coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 *.swp
 *.log
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 test
+coverage
 .eslint*
 .travis*
 .npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ install:
 
 script:
     - npm run lint
-    - npm test
+    - npm run cover
+    - npm run coveralls
 
 cache:
     directories:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "mocha",
     "lint": "eslint index.js \"lib/**\" \"test/**\"",
-    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\""
+    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",
+    "coveralls": "cat coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "htmlparser2": "^3.9.1"
   },
   "devDependencies": {
+    "coveralls": "^2.11.12",
     "eslint": "^3.3.1",
     "istanbul": "^0.4.5",
     "jsdomify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint index.js \"lib/**\" \"test/**\""
+    "lint": "eslint index.js \"lib/**\" \"test/**\"",
+    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\""
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "eslint": "^3.3.1",
+    "istanbul": "^0.4.5",
     "jsdomify": "^2.1.0",
     "mocha": "^3.0.2",
     "react": "*",


### PR DESCRIPTION
Resolves #11

#### Tasks:
- Setup [Istanbul](https://github.com/gotwarlost/istanbul) as the code coverage tool
- Setup [Coveralls](https://coveralls.io) as the test coverage reporter
- Integrate Coveralls with Travis
- Ignore `coverage` directory in `.gitignore` and `.npmignore`

#### npm scripts:
- `npm run cover`: Runs Istanbul and Mocha
- `npm run coveralls`: Sends coverage to Coveralls