### PR TITLE
Use webpack to build UMD bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 coverage
+dist
 *.swp
 *.log
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -1,63 +1,31 @@
-/* eslint-disable strict */
-// UMD template: https://github.com/ForbesLindesay/umd/blob/master/template.js
-;(function(factory) { // eslint-disable-line no-extra-semi
+'use strict';
 
-    // CommonJS
-    if (typeof exports === 'object' && typeof module !== 'undefined') {
-        module.exports = factory();
+/**
+ * Module dependencies.
+ */
+var domToReact = require('./lib/dom-to-react');
+var htmlToDOM = (
+    process.browser && process.title === 'browser' ?
+    require('./lib/html-to-dom-client') :
+    require('./lib/html-to-dom-server')
+);
 
-    // RequireJS (AMD)
-    } else if (typeof define === 'function' && define.amd) { // eslint-disable-line no-undef
-        define([], factory()); // eslint-disable-line no-undef
-
-    // Browser (script tag)
-    } else {
-        var root;
-        if (typeof window !== 'undefined') {
-            root = window;
-        } else if (typeof global !== 'undefined') {
-            root = global;
-        } else if (typeof self !== 'undefined') {
-            root = self;
-        } else {
-            // works provided we're not in strict mode
-            root = this;
-        }
-
-        // define namespace
-        root.HTMLReactParser = factory();
+/**
+ * Convert HTML string to React elements.
+ *
+ * @param  {String}   html              - The HTML.
+ * @param  {Object}   [options]         - The additional options.
+ * @param  {Function} [options.replace] - The replace method.
+ * @return {ReactElement|Array}
+ */
+function HTMLReactParser(html, options) {
+    if (typeof html !== 'string') {
+        throw new Error('`HTMLReactParser`: The first argument must be a string.');
     }
+    return domToReact(htmlToDOM(html), options);
+}
 
-})(function() {
-
-    var domToReact = require('./lib/dom-to-react');
-    var htmlToDOM;
-
-    // client (browser)
-    if (typeof window !== 'undefined' && this === window) {
-        htmlToDOM = require('./lib/html-to-dom-client');
-
-    // server (node)
-    } else {
-        htmlToDOM = require('./lib/html-to-dom-server');
-    }
-
-    /**
-     * Convert HTML string to React elements.
-     *
-     * @param  {String}   html              - The HTML.
-     * @param  {Object}   [options]         - The additional options.
-     * @param  {Function} [options.replace] - The replace method.
-     * @return {ReactElement|Array}
-     */
-    function HTMLReactParser(html, options) {
-        if (typeof html !== 'string') {
-            throw new Error('`HTMLReactParser`: The first argument must be a string.');
-        }
-        return domToReact(htmlToDOM(html), options);
-    }
-
-    // source
-    return HTMLReactParser;
-
-});
+/**
+ * Export HTML to React parser.
+ */
+module.exports = HTMLReactParser;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",
   "scripts": {
+    "build": "webpack index.js dist/html-to-react.js",
+    "build-min": "webpack -p index.js dist/html-to-react.min.js",
     "test": "mocha",
     "lint": "eslint index.js \"lib/**\" \"test/**\"",
     "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "jsdomify": "^2.1.0",
     "mocha": "^3.0.2",
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "webpack": "^1.13.2"
   },
   "peerDependencies": {
     "react": ">=0.14"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",
   "scripts": {
-    "build": "webpack index.js dist/html-to-react.js",
-    "build-min": "webpack -p index.js dist/html-to-react.min.js",
+    "build": "NODE_ENV=development webpack index.js dist/html-to-react.js",
+    "build-min": "NODE_ENV=production webpack -p index.js dist/html-to-react.min.js",
     "test": "mocha",
     "lint": "eslint index.js \"lib/**\" \"test/**\"",
     "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "NODE_ENV=development webpack index.js dist/html-to-react.js",
     "build-min": "NODE_ENV=production webpack -p index.js dist/html-to-react.min.js",
+    "prepublish": "npm run build && npm run build-min",
     "test": "mocha",
     "lint": "eslint index.js \"lib/**\" \"test/**\"",
     "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Export webpack configuration.
+ */
+module.exports = {
+    entry: './index',
+    output: {
+        filename: './dist/html-to-react.min.js',
+        library: 'HTMLReactParser',
+        libraryTarget: 'umd'
+    },
+    externals: {
+        'react': {
+            root: 'React',
+            commonjs2: 'react',
+            commonjs: 'react',
+            amd: 'react'
+        }
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * Module dependencies.
+ */
+var webpack = require('webpack');
+
+/**
  * Export webpack configuration.
  */
 module.exports = {
@@ -15,5 +20,11 @@ module.exports = {
             commonjs: 'react',
             amd: 'react'
         }
-    }
+    },
+    plugins: [
+        new webpack.optimize.OccurrenceOrderPlugin(),
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+        })
+    ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,9 +4,7 @@
  * Export webpack configuration.
  */
 module.exports = {
-    entry: './index',
     output: {
-        filename: './dist/html-to-react.min.js',
         library: 'HTMLReactParser',
         libraryTarget: 'umd'
     },


### PR DESCRIPTION
As an improvement of #6, let [webpack](https://webpack.github.io) handle building the [UMD bundle](https://webpack.github.io/docs/library-and-externals.html). Build inspired by [react-router](https://github.com/ReactTraining/react-router/blob/master/webpack.config.js).

The bundle will be generated in the `./dist/` directory as `html-react-parser.js` and `html-react-parser.min.js`.

#### Tasks:
- Create npm scripts:
  - `build`: Builds development/unminified bundle
  - `build-min`: Builds production/minified bundle
  - `prepublish`: Runs `build` and `build-min` before publish
- Save `webpack@1.13.2` and create `webpack.config.js`
- Add `dist` to `.gitignore`
