### PR TITLE
Fix regex bug on client parser

### DIFF
--- a/lib/html-to-dom-client.js
+++ b/lib/html-to-dom-client.js
@@ -102,13 +102,14 @@ function formatDOM(nodes, parentNode) {
  * @return {Object}      - The DOM nodes.
  */
 function htmlToDOMClient(html) {
-    var match = typeof html === 'string' ? html.match(/<(.+?)>/) : null;
+    // from `<p>` or `<p style="">` get `p`
+    var match = typeof html === 'string' ? html.match(/<(.+?)[>\s]/) : null;
     var tagName;
     var parentNode;
     var nodes;
 
     if (match && typeof match[1] === 'string') {
-        tagName = match[1].toLowerCase();
+        tagName = match[1].trim().toLowerCase();
     }
 
     // `DOMParser` can parse full HTML

--- a/test/html-to-dom.js
+++ b/test/html-to-dom.js
@@ -55,9 +55,35 @@ describe('html-to-dom', function() {
                 data.html.comment +
                 data.html.script
             );
-            helpers.deepEqualCircular(htmlToDOMClient(html), htmlToDOMServer(html));
+
+            helpers.deepEqualCircular(
+                htmlToDOMClient(html),
+                htmlToDOMServer(html)
+            );
         });
 
+        it('works with `window.DOMParser`', function() {
+            var html = (
+                data.html.attributes +
+                data.html.nested +
+                data.html.comment +
+                data.html.script
+            );
+
+            // mock `window.DOMParser`
+            // https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
+            window.DOMParser = function() {
+                this.parseFromString = function(html) {
+                    jsdomify.create(html);
+                    return document;
+                };
+            };
+
+            helpers.deepEqualCircular(
+                htmlToDOMClient(html),
+                htmlToDOMServer(html)
+            );
+        });
     });
 
 });


### PR DESCRIPTION
Fixes #23

#### Tasks:
- Fix regex so that only the tag name is matched for the client parser before being parsed by `window.DOMParser`
- Add test to ensure client parser does not break on regex and `DOMParser`