### PR TITLE
Rename dist filenames and add webpack to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 test
 coverage
+webpack.config.js
 .eslint*
 .travis*
 .npmignore

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=development webpack index.js dist/html-to-react.js",
-    "build-min": "NODE_ENV=production webpack -p index.js dist/html-to-react.min.js",
+    "build": "NODE_ENV=development webpack index.js dist/html-react-parser.js",
+    "build-min": "NODE_ENV=production webpack -p index.js dist/html-react-parser.min.js",
     "prepublish": "npm run build && npm run build-min",
     "test": "mocha",
     "lint": "eslint index.js \"lib/**\" \"test/**\"",


### PR DESCRIPTION
#### Chore:
- Rename dist output filenames:
  - `./dist/html-to-react.js` => `./dist/html-react-parser.js`
  - `./dist/html-to-react.min.js` => `./dist/html-react-parser.min.js`
- Add `webpack.config.js` to `.npmignore`

The published contents are now viewable on https://unpkg.com/html-react-parser/