### PR TITLE
Fix bug due to DOMPropertyConfigs being moved to `react-dom` in v15.4

### DIFF
--- a/lib/DOMPropertyConfig.js
+++ b/lib/DOMPropertyConfig.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var HTMLDOMPropertyConfig;
+var SVGDOMPropertyConfig;
+
+// HTML and SVG DOM Property Config
+// moved to `react-dom` in v15.4.x
+try {
+    HTMLDOMPropertyConfig = require('react-dom/lib/HTMLDOMPropertyConfig');
+    SVGDOMPropertyConfig = require('react-dom/lib/SVGDOMPropertyConfig');
+} catch (error) {
+    HTMLDOMPropertyConfig = require('react/lib/HTMLDOMPropertyConfig');
+    SVGDOMPropertyConfig = require('react/lib/SVGDOMPropertyConfig');
+}
+
+/**
+ * Export config.
+ */
+module.exports = {
+    HTMLDOMPropertyConfig: HTMLDOMPropertyConfig,
+    SVGDOMPropertyConfig: SVGDOMPropertyConfig
+};

--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -3,7 +3,7 @@
 /**
  * Module dependencies.
  */
-var HTMLDOMPropertyConfig = require('react/lib/HTMLDOMPropertyConfig');
+var HTMLDOMPropertyConfig = require('./DOMPropertyConfig').HTMLDOMPropertyConfig;
 var utilities = require('./utilities');
 var propertyConfig = require('./property-config');
 

--- a/lib/property-config.js
+++ b/lib/property-config.js
@@ -4,8 +4,9 @@
  * Module dependencies.
  */
 var utilities = require('./utilities');
-var HTMLDOMPropertyConfig = require('react/lib/HTMLDOMPropertyConfig');
-var SVGDOMPropertyConfig = require('react/lib/SVGDOMPropertyConfig');
+var DOMPropertyConfig = require('./DOMPropertyConfig');
+var HTMLDOMPropertyConfig = DOMPropertyConfig.HTMLDOMPropertyConfig;
+var SVGDOMPropertyConfig = DOMPropertyConfig.SVGDOMPropertyConfig;
 
 var config = {
     html: {},


### PR DESCRIPTION
Both `HTMLDOMPropertyConfig.js` and `SVGDOMPropertyConfig.js` used to be in `react/lib/` directory but since v15.4.x, the configs have been moved to `react-dom/lib/`.

Created a module that tried to require either `react-dom/lib/` or `react/lib/` (fallback).

#### Todo:

A more permanent (less error-prone) solution may be to keep a hardcopy of both configs in the repository (minimize coupling and risk of another change from breaking the package).

Update travis to test react and react-dom versions `15.3` and `15.4`.

Fixes #29