### PR TITLE
Require DOM property configs from `react-dom/lib/` in react >=15.4

### DIFF
--- a/lib/property-config.js
+++ b/lib/property-config.js
@@ -6,8 +6,8 @@
 var utilities = require('./utilities');
 
 // HTML and SVG DOM Property Configs
-var HTMLDOMPropertyConfig = require('react/lib/HTMLDOMPropertyConfig');
-var SVGDOMPropertyConfig = require('react/lib/SVGDOMPropertyConfig');
+var HTMLDOMPropertyConfig = require('react-dom/lib/HTMLDOMPropertyConfig');
+var SVGDOMPropertyConfig = require('react-dom/lib/SVGDOMPropertyConfig');
 
 var config = {
     html: {},

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "istanbul": "^0.4.5",
     "jsdomify": "^2.1.0",
     "mocha": "^3.0.2",
-    "react": "15.3",
-    "react-dom": "15.3",
+    "react": ">=15.4",
+    "react-dom": ">=15.4",
     "webpack": "^1.13.2"
   },
   "peerDependencies": {
-    "react": "<=15.3"
+    "react": ">=15.4",
+    "react-dom": ">=15.4"
   },
   "browser": {
     "htmlparser2/lib/Parser": false,


### PR DESCRIPTION
Following step after #31

This will hopefully support react latest as long as there are no more breaking changes. This will bump the package to `0.3.0`

Update `devDependencies` and `peerDependencies` in `package.json` to use `react` and `react-dom` `>=15.4`