### PR TITLE
Decode HTML entities by default on node

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@
 var domToReact = require('./lib/dom-to-react');
 var htmlToDOM = require('html-dom-parser');
 
+// decode HTML entities by default for `htmlparser2`
+var domParserOptions = { decodeEntities: true };
+
 /**
  * Convert HTML string to React elements.
  *
@@ -18,7 +21,7 @@ function HTMLReactParser(html, options) {
     if (typeof html !== 'string') {
         throw new TypeError('First argument must be a string');
     }
-    return domToReact(htmlToDOM(html), options);
+    return domToReact(htmlToDOM(html, domParserOptions), options);
 }
 
 /**

--- a/test/html-to-react.js
+++ b/test/html-to-react.js
@@ -78,6 +78,13 @@ describe('html-to-react', function() {
             assert.equal(render(reactElement), svg);
         });
 
+        it('decodes HTML entities', function() {
+            var encodedEntities = 'asdf &amp; &yuml; &uuml; &apos;';
+            var decodedEntities = 'asdf & ÿ ü \'';
+            var reactElement = Parser('<i>' + encodedEntities + '</i>');
+            assert.equal(reactElement.props.children, decodedEntities);
+        });
+
     });
 
     /**


### PR DESCRIPTION
#### Summary:

HTML entities aren't decoded by default for `htmlparser2` (initialized by `html-dom-parser`). As a result, this will lead to an `Invariant Violation` because the entities are decoded on the client-side.

The fix is to always set `decodeEntities: true` for `htmlparser2`.

Resolves #34.

#### Tasks:

- Set parser options `decodeEntities` to true for `html-dom-parser`, which gets passed to `htmlparser2`
- Write test to confirm that HTML entities passed to React element's children are properly decoded