### PR TITLE
Update examples and package.json

### DIFF
--- a/examples/requirejs.html
+++ b/examples/requirejs.html
@@ -13,7 +13,7 @@
         <script>
             requirejs.config({
                 paths: {
-                    'html-react-parser': 'https://unpkg.com/html-react-parser@latest/dist/html-react-parser.min',
+                    'html-react-parser': '../dist/html-react-parser.min',
                     'react': 'https://unpkg.com/react@latest/dist/react.min',
                     'react-dom': 'https://unpkg.com/react-dom@latest/dist/react-dom.min'
                 }

--- a/examples/script-tag.html
+++ b/examples/script-tag.html
@@ -7,12 +7,11 @@
     <body style="padding: 50px">
         <div id="root"></div>
 
-        <!-- HTMLReactParser depends on React -->
+        <!-- HTMLReactParser depends on React and ReactDOM -->
         <script src="https://unpkg.com/react@latest/dist/react.min.js"></script>
-        <script src="https://unpkg.com/html-react-parser@latest/dist/html-react-parser.min.js"></script>
-
-        <!-- ReactDOM -->
         <script src="https://unpkg.com/react-dom@latest/dist/react-dom.min.js"></script>
+        <script src="../dist/html-react-parser.min.js"></script>
+
         <script>
             ReactDOM.render(
                 HTMLReactParser(

--- a/package.json
+++ b/package.json
@@ -45,9 +45,5 @@
     "react": ">=15.4",
     "react-dom": ">=15.4"
   },
-  "browser": {
-    "htmlparser2/lib/Parser": false,
-    "domhandler": false
-  },
   "license": "MIT"
 }


### PR DESCRIPTION
#### Tasks:
- Update examples to load parser from relative `dist/` directory as this ensures the parser is the current version after running build
- Remove **"browser"** field from `package.json` since `html-dom-parser` handles it in its own package