### PR TITLE
Upgrade dependencies (html-dom-parser@0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased](https://github.com/remarkablemark/html-react-parser/compare/v0.3.3...HEAD)
+### Changed
+- Dependencies:
+  - html-dom-parser@0.1.0
+  - coveralls@2.13.1
+  - eslint@4.0.0
+  - mocha@3.4.2
+  - webpack@2.6.1
+
+### Removed
+- Dependencies:
+  - jsdomify
+
 ## [0.3.3](https://github.com/remarkablemark/html-react-parser/compare/v0.3.2...v0.3.3) - 2017-01-27
 ### Added
 - Created CHANGELOG with details on each version release (#37)

--- a/package.json
+++ b/package.json
@@ -32,14 +32,13 @@
     "html-dom-parser": "0.1.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.12",
-    "eslint": "^3.3.1",
+    "coveralls": "^2.13.1",
+    "eslint": "^4.0.0",
     "istanbul": "^0.4.5",
-    "jsdomify": "^2.1.0",
-    "mocha": "^3.0.2",
+    "mocha": "^3.4.2",
     "react": ">=15.4",
     "react-dom": ">=15.4",
-    "webpack": "^1.13.2"
+    "webpack": "^2.6.1"
   },
   "peerDependencies": {
     "react": ">=15.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "converter"
   ],
   "dependencies": {
-    "html-dom-parser": "0.0.2"
+    "html-dom-parser": "0.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.12",


### PR DESCRIPTION
Resolves #39

- dependencies:
  - html-dom-parser@0.1.0
- devDependencies:
  - coveralls@2.13.1
  - eslint@4.0.0
  - mocha@3.4.2
  - webpack@2.6.1