### PR TITLE
Fix component style attribute parser

### DIFF
--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -5,6 +5,7 @@
  */
 var utilities = require('./utilities');
 var propertyConfig = require('./property-config');
+var cssToReactNative = require('css-to-react-native');
 var config = propertyConfig.config;
 var isCustomAttribute = propertyConfig.HTMLDOMPropertyConfig.isCustomAttribute;
 
@@ -63,33 +64,16 @@ function cssToJs(style) {
         throw new Error('`cssToJs`: first argument must be a string. ');
     }
 
-    var result = {};
-    // e.g., `color: #f00`
-    var declarations = style.split(';');
-    // css property itemized as key and value
-    var properties;
-    var j;
-    var propertiesLen;
+    var styles = style.split(';');
+    styles = styles.map(function (style) {
+        var parts = style.split(':');
+        var propName = parts[0];
+        parts.shift();
+        var propValue = parts.join(':');
+        return [propName.trim(), propValue.trim()];
+    });
 
-    for (var i = 0, declarationsLen = declarations.length; i < declarationsLen; i++) {
-        properties = declarations[i].trim().split(':');
-
-        // skip if not a css property
-        if (properties.length !== 2) { continue; }
-
-        // css property name
-        properties[0] = properties[0].trim();
-        // css property value
-        properties[1] = properties[1].trim();
-
-        if (properties[0] && properties[1]) {
-            for (j = 0, propertiesLen = properties.length; j < propertiesLen; j++) {
-                result[utilities.camelCase(properties[0])] = properties[1];
-            }
-        }
-    }
-
-    return result;
+    return cssToReactNative.default(styles);
 }
 
 /**

--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -5,7 +5,7 @@
  */
 var utilities = require('./utilities');
 var propertyConfig = require('./property-config');
-var csstree = require('css-tree');
+var parser = require('style-to-object');
 var config = propertyConfig.config;
 var isCustomAttribute = propertyConfig.HTMLDOMPropertyConfig.isCustomAttribute;
 
@@ -66,17 +66,12 @@ function cssToJs(style) {
 
     var styleObj = {};
 
-    var ast = csstree.parse(style, {
-        context: 'declarationList',
-        parseValue: false
+    parser(style, function(propName, propValue) {
+        styleObj[utilities.camelCase(propName)] = propValue;
     });
 
-    csstree.walk(ast, function (node) {
-        if(node.type === 'Declaration') {
-            var propertyCamelCase = node.property.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
-            styleObj[propertyCamelCase] = node.value.value;
-        }
-    });
+    console.log(styleObj);
+
 
     return styleObj;
 }

--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -70,9 +70,6 @@ function cssToJs(style) {
         styleObj[utilities.camelCase(propName)] = propValue;
     });
 
-    console.log(styleObj);
-
-
     return styleObj;
 }
 

--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -5,7 +5,7 @@
  */
 var utilities = require('./utilities');
 var propertyConfig = require('./property-config');
-var cssToReactNative = require('css-to-react-native');
+var csstree = require('css-tree');
 var config = propertyConfig.config;
 var isCustomAttribute = propertyConfig.HTMLDOMPropertyConfig.isCustomAttribute;
 
@@ -64,16 +64,21 @@ function cssToJs(style) {
         throw new Error('`cssToJs`: first argument must be a string. ');
     }
 
-    var styles = style.split(';');
-    styles = styles.map(function (style) {
-        var parts = style.split(':');
-        var propName = parts[0];
-        parts.shift();
-        var propValue = parts.join(':');
-        return [propName.trim(), propValue.trim()];
+    var styleObj = {};
+
+    var ast = csstree.parse(style, {
+        context: 'declarationList',
+        parseValue: false
     });
 
-    return cssToReactNative.default(styles);
+    csstree.walk(ast, function (node) {
+        if(node.type === 'Declaration') {
+            var propertyCamelCase = node.property.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+            styleObj[propertyCamelCase] = node.value.value;
+        }
+    });
+
+    return styleObj;
 }
 
 /**

--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -5,7 +5,7 @@
  */
 var utilities = require('./utilities');
 var propertyConfig = require('./property-config');
-var parser = require('style-to-object');
+var styleToObject = require('style-to-object');
 var config = propertyConfig.config;
 var isCustomAttribute = propertyConfig.HTMLDOMPropertyConfig.isCustomAttribute;
 
@@ -66,8 +66,11 @@ function cssToJs(style) {
 
     var styleObj = {};
 
-    parser(style, function(propName, propValue) {
-        styleObj[utilities.camelCase(propName)] = propValue;
+    styleToObject(style, function(propName, propValue) {
+        // Check if it's not a comment node
+        if (propName && propValue) {
+            styleObj[utilities.camelCase(propName)] = propValue;
+        }
     });
 
     return styleObj;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -10,7 +10,13 @@
 var _hyphenPattern = /-(.)/g;
 
 function camelCase(string) {
-    return string.replace(_hyphenPattern, function(_, character) {
+    if (typeof string !== 'string') { // null is an object
+        throw new TypeError('First argument must be a string');
+    }
+    if(string.indexOf('-') < 0) {
+        return string;
+    }
+    return string.toLowerCase().replace(_hyphenPattern, function(_, character) {
         return character.toUpperCase();
     });
 }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,14 +1,13 @@
 'use strict';
 
+var _hyphenPattern = /-(.)/g;
+
 /**
  * Convert a string to camel case.
  *
  * @param  {String} string - The string.
  * @return {String}
  */
-
-var _hyphenPattern = /-(.)/g;
-
 function camelCase(string) {
     if (typeof string !== 'string') { // null is an object
         throw new TypeError('First argument must be a string');

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -6,24 +6,13 @@
  * @param  {String} string - The string.
  * @return {String}
  */
+
+var _hyphenPattern = /-(.)/g;
+
 function camelCase(string) {
-    if (typeof string !== 'string') {
-        throw new TypeError('First argument must be a string');
-    }
-
-    // hyphen found after first character
-    if (string.indexOf('-') > 0) {
-        var strings = string.toLowerCase().split('-');
-
-        // capitalize starting from the second string item
-        for (var i = 1, len = strings.length; i < len; i++) {
-            strings[i] = strings[i].charAt(0).toUpperCase() + strings[i].slice(1);
-        }
-
-        return strings.join('');
-    }
-
-    return string;
+    return string.replace(_hyphenPattern, function(_, character) {
+        return character.toUpperCase();
+    });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "html-dom-parser": "0.1.2",
     "react-dom-core": "0.0.2",
-    "style-to-object": "^0.2.0"
+    "style-to-object": "0.2.0"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "converter"
   ],
   "dependencies": {
+    "css-to-react-native": "^2.0.4",
     "html-dom-parser": "0.1.2",
     "react-dom-core": "0.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "converter"
   ],
   "dependencies": {
-    "css-to-react-native": "^2.0.4",
+    "css-tree": "^1.0.0-alpha.26",
     "html-dom-parser": "0.1.2",
     "react-dom-core": "0.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "converter"
   ],
   "dependencies": {
-    "css-tree": "^1.0.0-alpha.26",
     "html-dom-parser": "0.1.2",
-    "react-dom-core": "0.0.2"
+    "react-dom-core": "0.0.2",
+    "style-to-object": "^0.2.0"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/test/attributes-to-props.js
+++ b/test/attributes-to-props.js
@@ -168,7 +168,7 @@ describe('attributes to props helper', function() {
                         fontSize: '42px',
                         zIndex: '-1',
                         MozBorderRadiusTopright: '10px',
-                        background: "url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)"
+                        background: 'url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)'
                     }
                 }
             );

--- a/test/attributes-to-props.js
+++ b/test/attributes-to-props.js
@@ -160,13 +160,15 @@ describe('attributes to props helper', function() {
             // proper css
             assert.deepEqual(
                 attributesToProps({
-                    style: 'color: #f00; font-size: 42px; z-index: -1;'
+                    style: 'color: #f00; font-size: 42px; z-index: -1; -moz-border-radius-topright: 10px; background: url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)'
                 }),
                 {
                     style: {
                         color: '#f00',
                         fontSize: '42px',
-                        zIndex: '-1'
+                        zIndex: '-1',
+                        MozBorderRadiusTopright: '10px',
+                        background: "url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)"
                     }
                 }
             );
@@ -174,13 +176,14 @@ describe('attributes to props helper', function() {
             // valid but messy
             assert.deepEqual(
                 attributesToProps({
-                    style: 'border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1'
+                    style: 'border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px'
                 }),
                 {
                     style: {
                         borderBottomLeftRadius: '1em',
                         borderRightStyle: 'solid',
-                        zIndex: '-1'
+                        zIndex: '-1',
+                        MozBorderRadiusBottomleft: '20px'
                     }
                 }
             );


### PR DESCRIPTION
When we have a style attribute on the original HTML, the parsing was not correct, specially with background-image with an external URL, this was not loading because of a split by ':' what breaks the URL. I added an library that generates a more complete style tag using css-to-react-native.