### PR TITLE
Some SVG attributes aren't correctly handled, for example viewBox

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var domToReact = require('./lib/dom-to-react');
 var htmlToDOM = require('html-dom-parser');
 
 // decode HTML entities by default for `htmlparser2`
-var domParserOptions = { decodeEntities: true };
+var domParserOptions = { decodeEntities: true, lowerCaseAttributeNames: false };
 
 /**
  * Convert HTML string to React elements.

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -128,4 +128,14 @@ describe('dom-to-react parser', function() {
         );
     });
 
+    
+    it('handles svg\'s with a viewBox', function() {
+        var html = mocks.html.svg;
+        var reactElement = domToReact(htmlToDOM(html));
+
+        assert.deepEqual(
+            reactElement,
+            React.createElement('svg', { viewBox: '0 0 512 512', id: 'foo' }, 'Inner')
+        );
+    });
 });

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -133,8 +133,6 @@ describe('dom-to-react parser', function() {
         var html = mocks.html.svg;
         var reactElement = domToReact(htmlToDOM(html, { lowerCaseAttributeNames: false }));
 
-        console.log(reactElement);
-
         assert.deepEqual(
             reactElement,
             React.createElement('svg', { viewBox: '0 0 512 512', id: 'foo' }, 'Inner')

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -130,7 +130,7 @@ describe('dom-to-react parser', function() {
 
     
     it('handles svg\'s with a viewBox', function() {
-        var html = mocks.html.svg;
+        var html = mocks.svg.simple;
         var reactElement = domToReact(htmlToDOM(html, { lowerCaseAttributeNames: false }));
 
         assert.deepEqual(

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -131,7 +131,9 @@ describe('dom-to-react parser', function() {
     
     it('handles svg\'s with a viewBox', function() {
         var html = mocks.html.svg;
-        var reactElement = domToReact(htmlToDOM(html));
+        var reactElement = domToReact(htmlToDOM(html, { lowerCaseAttributeNames: false }));
+
+        console.log(reactElement);
 
         assert.deepEqual(
             reactElement,

--- a/test/helpers/mocks.json
+++ b/test/helpers/mocks.json
@@ -11,10 +11,10 @@
     "img": "<img src=\"http://stat.ic/img.jpg\" alt=\"Image\"/>",
     "void": "<link/><meta/><img/><br/><hr/><input/>",
     "comment": "<!-- comment -->",
-    "doctype": "<!DOCTYPE html>",
-    "svg": "<svg viewBox=\"0 0 512 512\" id=\"foo\">Inner</svg>"
+    "doctype": "<!DOCTYPE html>"
   },
   "svg": {
+    "simple": "<svg viewBox=\"0 0 512 512\" id=\"foo\">Inner</svg>",
     "complex": "<svg height=\"400\" width=\"450\"><path id=\"lineAB\" d=\"M 100 350 l 150 -300\" stroke=\"red\" stroke-width=\"3\" fill=\"none\"></path><g stroke=\"black\" stroke-width=\"3\" fill=\"black\"><circle id=\"pointA\" cx=\"100\" cy=\"350\" r=\"3\"></circle></g><g font-size=\"30\" font-family=\"sans-serif\" fill=\"black\" stroke=\"none\" text-anchor=\"middle\"><text x=\"100\" y=\"350\" dx=\"-30\">A</text></g>Your browser does not support inline SVG.</svg>"
   }
 }

--- a/test/helpers/mocks.json
+++ b/test/helpers/mocks.json
@@ -11,7 +11,8 @@
     "img": "<img src=\"http://stat.ic/img.jpg\" alt=\"Image\"/>",
     "void": "<link/><meta/><img/><br/><hr/><input/>",
     "comment": "<!-- comment -->",
-    "doctype": "<!DOCTYPE html>"
+    "doctype": "<!DOCTYPE html>",
+    "svg": "<svg viewBox=\"0 0 512 512\" id=\"foo\">Inner</svg>"
   },
   "svg": {
     "complex": "<svg height=\"400\" width=\"450\"><path id=\"lineAB\" d=\"M 100 350 l 150 -300\" stroke=\"red\" stroke-width=\"3\" fill=\"none\"></path><g stroke=\"black\" stroke-width=\"3\" fill=\"black\"><circle id=\"pointA\" cx=\"100\" cy=\"350\" r=\"3\"></circle></g><g font-size=\"30\" font-family=\"sans-serif\" fill=\"black\" stroke=\"none\" text-anchor=\"middle\"><text x=\"100\" y=\"350\" dx=\"-30\">A</text></g>Your browser does not support inline SVG.</svg>"


### PR DESCRIPTION
The implementation assumes all attributes are lowercase, this [isn't the case for SVGs](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#Specific_attributes). As a result when trying to map attributes to props the `viewBox` attribute breaks. 

https://unpkg.com/react-dom@15.6.2/lib/SVGDOMPropertyConfig.js