### PR TITLE
Adding options for `domParserOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.4.8"></a>
+## [0.4.8](https://github.com/remarkablemark/html-react-parser/compare/v0.4.7...v0.4.8) (2018-12-04)
+
+
+
 <a name="0.4.7"></a>
 ## [0.4.7](https://github.com/remarkablemark/html-react-parser/compare/v0.4.6...v0.4.7) (2018-09-14)
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ var domToReact = require('./lib/dom-to-react');
 var htmlToDOM = require('html-dom-parser');
 
 // decode HTML entities by default for `htmlparser2`
-var domParserOptions = { decodeEntities: true, lowerCaseAttributeNames: false };
+var defaultDomParserOptions = {
+  decodeEntities: true,
+  lowerCaseAttributeNames: false
+};
 
 /**
  * Convert HTML string to React elements.
@@ -10,12 +13,26 @@ var domParserOptions = { decodeEntities: true, lowerCaseAttributeNames: false };
  * @param  {String}   html              - The HTML string.
  * @param  {Object}   [options]         - The additional options.
  * @param  {Function} [options.replace] - The replace method.
+ * @param  {Object}   [options.domParserOptions] - Additional domParserOptions options.
  * @return {ReactElement|Array}
  */
 function HTMLReactParser(html, options) {
   if (typeof html !== 'string') {
     throw new TypeError('First argument must be a string');
   }
+
+  // adding new options to domParserOptions
+  // var domParserOptions = Object.assign(defaultDomParserOptions, (options && options.domParserOptions) || {});
+  var domParserOptions = defaultDomParserOptions;
+  if (options && options.domParserOptions instanceof Object) {
+    domParserOptions = options.domParserOptions;
+    for (var key in defaultDomParserOptions) {
+      if (domParserOptions[key] === undefined) {
+        domParserOptions[key] = defaultDomParserOptions[key];
+      }
+    }
+  }
+
   return domToReact(htmlToDOM(html, domParserOptions), options);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-react-parser",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "An HTML to React parser.",
   "author": "Mark <mark@remarkablemark.org>",
   "main": "index.js",

--- a/test/helpers/data.json
+++ b/test/helpers/data.json
@@ -11,7 +11,8 @@
     "img": "<img src=\"http://stat.ic/img.jpg\" alt=\"Image\"/>",
     "void": "<link/><meta/><img/><br/><hr/><input/>",
     "comment": "<!-- comment -->",
-    "doctype": "<!DOCTYPE html>"
+    "doctype": "<!DOCTYPE html>",
+    "special": "<SpecialTag>inside</SpecialTag>"
   },
   "svg": {
     "simple": "<svg viewBox=\"0 0 512 512\" id=\"foo\">Inner</svg>",

--- a/test/html-to-react.js
+++ b/test/html-to-react.js
@@ -109,5 +109,19 @@ describe('html-to-react', () => {
         );
       });
     });
+
+    describe('domParserOptions', () => {
+      it('lowerCaseTags `false` passed to htmlToDOM, should drop a React warning', () => {
+        const html = data.html.special;
+        const closedTag = '<SpecialTag>inside</SpecialTag>';
+        const reactElement = Parser(html, {
+          domParserOptions: {
+            lowerCaseTags: false
+          }
+        });
+        const elementRender = render(reactElement);
+        assert.equal(elementRender, closedTag);
+      });
+    });
   });
 });


### PR DESCRIPTION
Adding options for `domParserOptions` using Object.assign before send it directly to the parser itself;
Setting up a default value for `domParserOptions`;

Consider a possible refactoring, I am using github interface to update it.

I believe it closes #62 