### PR TITLE
DomToReact: Allow custom keys for replacement

### DIFF
--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -30,7 +30,9 @@ function domToReact(nodes, options) {
         // specify a "key" prop if element has siblings
         // https://fb.me/react-warning-keys
         if (len > 1) {
-          replacement = React.cloneElement(replacement, { key: i });
+          replacement = React.cloneElement(replacement, {
+            key: replacement.key || i
+          });
         }
         result.push(replacement);
         continue;

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -159,7 +159,7 @@ describe('dom-to-react parser', () => {
     );
   });
 
-  it('does not modify keys for replacement if it have one', () => {
+  it('does not modify keys for replacement if it has one', () => {
     const html = [data.html.single, data.html.customElement].join('');
 
     const reactElements = domToReact(htmlToDOM(html), {
@@ -171,7 +171,7 @@ describe('dom-to-react parser', () => {
           return React.createElement(
             'custom-button',
             {
-              key: 'meyKey',
+              key: 'myKey',
               class: 'myClass',
               'custom-attribute': 'replaced value'
             },
@@ -186,7 +186,7 @@ describe('dom-to-react parser', () => {
       React.createElement(
         'custom-button',
         {
-          key: 'meyKey',
+          key: 'myKey',
           class: 'myClass',
           'custom-attribute': 'replaced value'
         },

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -159,6 +159,42 @@ describe('dom-to-react parser', () => {
     );
   });
 
+  it('does not modify keys for replacement if it have one', () => {
+    const html = [data.html.single, data.html.customElement].join('');
+
+    const reactElements = domToReact(htmlToDOM(html), {
+      replace: node => {
+        if (node.name === 'p') {
+          return React.createElement('p', {}, 'replaced foo');
+        }
+        if (node.name === 'custom-button') {
+          return React.createElement(
+            'custom-button',
+            {
+              key: 'meyKey',
+              class: 'myClass',
+              'custom-attribute': 'replaced value'
+            },
+            null
+          );
+        }
+      }
+    });
+
+    assert.deepEqual(reactElements, [
+      React.createElement('p', { key: 0 }, 'replaced foo'),
+      React.createElement(
+        'custom-button',
+        {
+          key: 'meyKey',
+          class: 'myClass',
+          'custom-attribute': 'replaced value'
+        },
+        null
+      )
+    ]);
+  });
+
   describe('when React <16', () => {
     const { PRESERVE_CUSTOM_ATTRIBUTES } = utilities;
 


### PR DESCRIPTION
In current implementation when you use dom-to-react with replace option created elements usually have keys generated from index of node, even if component in replace have it's own key. 

According to https://fb.me/react-warning-keys 
"We don’t recommend using indexes for keys if the order of items may change. This can negatively impact performance and may cause issues with component state. "

In our case it cause problems with performance. 
This pull request will allow using keys from replacement components (for example id of element can be used as key if put it as key to component returned by replace).