### PR TITLE
update code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,27 @@ The following [example](https://repl.it/@remarkablemark/html-react-parser-replac
 ```jsx
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import parse from 'html-react-parser';
-import domToReact from 'html-react-parser/lib/dom-to-react';
+import parse, {domToReact} from 'html-react-parser';
+
+const parserOptions = {
+  replace: ({ attribs, children }) => {
+    if (!attribs) return;
+
+    if (attribs.id === 'main') {
+      return (
+        <h1 style={{ fontSize: 42 }}>
+          {domToReact(children, parserOptions)}
+        </h1>
+      );
+    } else if (attribs.class === 'prettify') {
+      return (
+        <span style={{ color: 'hotpink' }}>
+          {domToReact(children, parserOptions)}
+        </span>
+      );
+    }
+  }
+};
 
 const elements = parse(
   `
@@ -133,25 +152,7 @@ const elements = parse(
     </span>
   </p>
 `,
-  {
-    replace: ({ attribs, children }) => {
-      if (!attribs) return;
-
-      if (attribs.id === 'main') {
-        return (
-          <h1 style={{ fontSize: 42 }}>
-            {domToReact(children, parserOptions)}
-          </h1>
-        );
-      } else if (attribs.class === 'prettify') {
-        return (
-          <span style={{ color: 'hotpink' }}>
-            {domToReact(children, parserOptions)}
-          </span>
-        );
-      }
-    }
-  }
+  parserOptions
 );
 
 console.log(renderToStaticMarkup(elements));


### PR DESCRIPTION
## What is the motivation for this pull request?

Better documentation

## What is the current behavior?

Currently, the code sample in the README makes reference to a variable called `parserOptions`, even though that variable does not exist within the sample.

It seems that this variable is actually a reference to the object that contains the `replace` method, and that object should get passed in as the second argument to the calls to `domToReact`.

## What is the new behavior?

The new code sample creates a constant called `parserOptions`, which can then be passed as the second argument to `domToReact`.

Thanks!