### PR TITLE
[feature] replace supports return false and node object

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,38 @@ Console output:
   parent: null }
 ```
 
-The element is replaced only if a _valid_ React element is returned:
+The element is replaced if a _valid_ React element is returned:
 
 ```js
 parse('<p id="replace">text</p>', {
   replace: domNode => {
     if (domNode.attribs && domNode.attribs.id === 'replace') {
       return React.createElement('span', {}, 'replaced');
+    }
+  }
+});
+```
+
+Or you can just modify domNode object:
+
+```js
+parse('<p id="replace">text</p>', {
+  replace: domNode => {
+    if (domNode.attribs && domNode.attribs.id === 'replace') {
+      domNode.name = 'div';
+      return domNode;
+    }
+  }
+});
+```
+
+you can remove node if false returned:
+
+```js
+parse('<p id="replace">text</p>', {
+  replace: domNode => {
+    if (domNode.attribs && domNode.attribs.id === 'replace') {
+      return false;
     }
   }
 });

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -30,6 +30,11 @@ function domToReact(nodes, options) {
     if (hasReplace) {
       replaceElement = options.replace(node);
 
+      // remove node with null
+      if (replaceElement === null) {
+        continue;
+      }
+
       if (isValidElement(replaceElement)) {
         // specify a "key" prop if element has siblings
         // https://fb.me/react-warning-keys

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -30,12 +30,10 @@ function domToReact(nodes, options) {
     if (hasReplace) {
       replaceElement = options.replace(node);
 
-      // remove node with null
-      if (replaceElement === null) {
+      if (replaceElement === false) {
+        // remove node with false
         continue;
-      }
-
-      if (isValidElement(replaceElement)) {
+      } else if (isValidElement(replaceElement)) {
         // specify a "key" prop if element has siblings
         // https://fb.me/react-warning-keys
         if (len > 1) {
@@ -45,6 +43,9 @@ function domToReact(nodes, options) {
         }
         result.push(replaceElement);
         continue;
+      } else if (utilities.isValidParserNode(replaceElement)) {
+        // replace ast node with return node object
+        node = replaceElement;
       }
     }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -97,6 +97,19 @@ function isCustomComponent(tagName, props) {
 }
 
 /**
+ * Check if a give object is a parser node
+ *
+ * @param {Object} node - parser node
+ */
+function isValidParserNode(node) {
+  if (typeof node !== 'object' || !node.type || !node.name || !node.attribs) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * @constant {Boolean}
  * @see {@link https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html}
  */
@@ -106,5 +119,6 @@ module.exports = {
   PRESERVE_CUSTOM_ATTRIBUTES: PRESERVE_CUSTOM_ATTRIBUTES,
   camelCase: camelCase,
   invertObject: invertObject,
-  isCustomComponent: isCustomComponent
+  isCustomComponent: isCustomComponent,
+  isValidParserNode: isValidParserNode
 };

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -195,6 +195,31 @@ describe('dom-to-react parser', () => {
     ]);
   });
 
+  it('replace function support replace node', () => {
+    const html = data.html.single;
+    const reactElements = domToReact(htmlToDOM(html), {
+      replace: node => {
+        if (node.name === 'p') {
+          node.name = 'div';
+          return node;
+        }
+      }
+    });
+    assert.deepEqual(reactElements, React.createElement('div', {}, 'foo'));
+  });
+
+  it('delete node if replace return false', () => {
+    const html = data.html.single;
+    const reactElements = domToReact(htmlToDOM(html), {
+      replace: node => {
+        if (node.name === 'p') {
+          return false;
+        }
+      }
+    });
+    assert.deepEqual(reactElements, {});
+  });
+
   describe('when React <16', () => {
     const { PRESERVE_CUSTOM_ATTRIBUTES } = utilities;
 

--- a/test/dom-to-react.js
+++ b/test/dom-to-react.js
@@ -217,7 +217,7 @@ describe('dom-to-react parser', () => {
         }
       }
     });
-    assert.deepEqual(reactElements, {});
+    assert.deepEqual(reactElements, []);
   });
 
   describe('when React <16', () => {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -4,7 +4,8 @@ const {
   PRESERVE_CUSTOM_ATTRIBUTES,
   camelCase,
   invertObject,
-  isCustomComponent
+  isCustomComponent,
+  isValidParserNode
 } = require('../lib/utilities');
 
 describe('utilties.camelCase', () => {
@@ -105,6 +106,26 @@ describe('utilities.isCustomComponent', () => {
 
   it('returns true if the props contains an `is` key', () => {
     assert.equal(isCustomComponent('button', { is: 'custom-button' }), true);
+  });
+});
+
+describe('utilities.isValidParserNode', () => {
+  it('return true', () => {
+    assert.equal(
+      isValidParserNode({ type: 'tag', name: 'div', attribs: {} }),
+      true
+    );
+  });
+  it('return false if params is not object', () => {
+    assert.equal(isValidParserNode('not object'), false);
+    assert.equal(isValidParserNode(1), false);
+    assert.equal(isValidParserNode(true), false);
+    assert.equal(isValidParserNode(), false);
+  });
+  it('return false if object not contains require properties', () => {
+    assert.equal(isValidParserNode({}), false);
+    assert.equal(isValidParserNode({ type: 'tag' }), false);
+    assert.equal(isValidParserNode({ type: 'tag', name: 'div' }), false);
   });
 });
 


### PR DESCRIPTION
<!-- Filling out the information below can facilitate the review/merge of the PR. -->

## What is the motivation for this pull request?

Add feature to replace method. 

<!-- Is this a feature, bug fix, docs, etc.? -->

## What is the current behavior?

replace method only support return React Element now. It's difficult if we want remove or modify element. I can return modified React Element, but it's not easy for some node which has children.

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?

If replace method return false boolean we can remove this node, and if replace method return a parser node, we can update html AST node. 

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so:
- [x] Tests
-->

- [x] Tests
- [x] Documentation

<!--
Do you have any additional comments?
Thanks for contributing!
-->
