### PR TITLE
docs(readme): change parserOptions to options in longest example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ const options = {
 
     if (attribs.id === 'main') {
       return (
-        <h1 style={{ fontSize: 42 }}>{domToReact(children, parserOptions)}</h1>
+        <h1 style={{ fontSize: 42 }}>{domToReact(children, options)}</h1>
       );
     }
 
     if (attribs.class === 'prettify') {
       return (
         <span style={{ color: 'hotpink' }}>
-          {domToReact(children, parserOptions)}
+          {domToReact(children, options)}
         </span>
       );
     }


### PR DESCRIPTION
Changed `parserOptions` to `options` in the longest example.

Fixes #122

<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
