### PR TITLE
build(package): upgrade dependency html-dom-parser@0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@types/domhandler": "2.4.1",
-    "html-dom-parser": "0.2.2",
+    "html-dom-parser": "0.2.3",
     "react-property": "1.0.1",
     "style-to-object": "0.2.3"
   },


### PR DESCRIPTION
```
html-dom-parser    0.2.2  →   0.2.3
```

This fixes a bug related to client-side DOM parsing for unclosed HTML markup.

Relates to #126 and remarkablemark/html-dom-parser#18