### PR TITLE
fix: make `replace` optional in type declaration and update JSDoc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,9 @@ import htmlToDOM from 'html-dom-parser';
 
 export interface HTMLReactParserOptions {
   // TODO: Replace `object` by type for objects like `{ type: 'h1', props: { children: 'Heading' } }`
-  replace(domNode: DomElement): React.ReactElement | object | undefined | false;
+  replace?: (
+    domNode: DomElement
+  ) => React.ReactElement | object | void | undefined | null | false;
   library?: object;
 }
 

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -4,10 +4,11 @@ var utilities = require('./utilities');
 /**
  * Converts DOM nodes to React elements.
  *
- * @param  {Array}    nodes             - The DOM nodes.
- * @param  {Object}   [options]         - The additional options.
- * @param  {Function} [options.replace] - The replace method.
- * @return {ReactElement|Array}
+ * @param {DomElement[]} nodes - The DOM nodes.
+ * @param {Object} [options={}] - The additional options.
+ * @param {Function} [options.replace] - The replacer.
+ * @param {Object} [options.library] - The library (React, Preact, etc.).
+ * @return {String|ReactElement|ReactElement[]}
  */
 function domToReact(nodes, options) {
   options = options || {};
@@ -95,6 +96,10 @@ function domToReact(nodes, options) {
   return result.length === 1 ? result[0] : result;
 }
 
+/**
+ * @param {React.ReactElement} node
+ * @return {Boolean}
+ */
 function shouldPassAttributesUnaltered(node) {
   return (
     utilities.PRESERVE_CUSTOM_ATTRIBUTES &&


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes `index.d.ts` by making `replace` property optional in the 2nd argument object.

Also, updated and fixed incorrect JSDoc in `lib/dom-to-react.js`.

## What is the current behavior?

If a 2nd argument is specified, `replace` is required so instead of:

```js
{ replace: undefined }
```

Developers are forced to:

```js
{ replace: () => {} }
```

See #134

## What is the new behavior?

Developers are no longer forced to satisfy the type requirements. See above.

## Checklist:

- [x] Documentation