### PR TITLE
fix: use JSX.Element for type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 // TypeScript Version: 3.3
 
-import * as React from 'react';
 import { DomElement } from 'domhandler';
 import domToReact from './lib/dom-to-react';
 import htmlToDOM from 'html-dom-parser';
@@ -9,24 +8,21 @@ export interface HTMLReactParserOptions {
   // TODO: Replace `object` by type for objects like `{ type: 'h1', props: { children: 'Heading' } }`
   replace?: (
     domNode: DomElement
-  ) => React.ReactElement | object | void | undefined | null | false;
+  ) => JSX.Element | object | void | undefined | null | false;
   library?: object;
 }
 
 /**
  * Converts HTML string to React elements.
  *
- * @param  html    - The HTML string to parse to React.
+ * @param  html    - The HTML string to parse to JSX.
  * @param  options - The parser options.
  * @return         - When parsed with HTML string, returns React elements; otherwise, returns string or empty array.
  */
 declare function HTMLReactParser(
   html: string,
   options?: HTMLReactParserOptions
-):
-  | string
-  | React.DetailedReactHTMLElement<{}, HTMLElement>
-  | Array<React.DetailedReactHTMLElement<{}, HTMLElement>>;
+): ReturnType<typeof domToReact>;
 
 export { DomElement, domToReact, htmlToDOM };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,11 +13,11 @@ export interface HTMLReactParserOptions {
 }
 
 /**
- * Converts HTML string to React elements.
+ * Converts HTML string to JSX element(s).
  *
- * @param  html    - The HTML string to parse to JSX.
+ * @param  html    - The HTML string to parse to JSX element(s).
  * @param  options - The parser options.
- * @return         - When parsed with HTML string, returns React elements; otherwise, returns string or empty array.
+ * @return         - Single or array of JSX elements.
  */
 declare function HTMLReactParser(
   html: string,

--- a/lib/dom-to-react.d.ts
+++ b/lib/dom-to-react.d.ts
@@ -1,17 +1,16 @@
 // TypeScript Version: 3.3
 
-import * as React from 'react';
 import { HTMLReactParserOptions } from '..';
 import { DomElement } from 'domhandler';
 
 /**
  * Converts DOM nodes to React elements.
  *
- * @param nodes - A list of formatted DomNodes to convert to React.
- * @param options - Options to use when converting to react.
- * @returns ReactElement or and array of ReactElements.
+ * @param nodes - A list of formatted DomNodes to convert to JSX.
+ * @param options - Options to use when converting to JSX.
+ * @returns JSX.Element or an array of JSX.Elements.
  */
 export default function domToReact(
   nodes: DomElement[],
   options?: HTMLReactParserOptions
-): React.ReactElement | React.ReactElement[];
+): JSX.Element | JSX.Element[];

--- a/lib/dom-to-react.d.ts
+++ b/lib/dom-to-react.d.ts
@@ -4,11 +4,11 @@ import { HTMLReactParserOptions } from '..';
 import { DomElement } from 'domhandler';
 
 /**
- * Converts DOM nodes to React elements.
+ * Converts DOM nodes to JSX element(s).
  *
- * @param nodes - A list of formatted DomNodes to convert to JSX.
+ * @param nodes - An array of DomNodes to convert to JSX element(s).
  * @param options - Options to use when converting to JSX.
- * @returns JSX.Element or an array of JSX.Elements.
+ * @returns Single or array of JSX elements.
  */
 export default function domToReact(
   nodes: DomElement[],

--- a/test/types/index.test.tsx
+++ b/test/types/index.test.tsx
@@ -1,7 +1,7 @@
 import parse, { HTMLReactParserOptions, domToReact, htmlToDOM } from 'html-react-parser';
 import * as React from 'react';
 
-// $ExpectType string | DetailedReactHTMLElement<{}, HTMLElement> | DetailedReactHTMLElement<{}, HTMLElement>[]
+/* $ExpectType ReactElement | ReactElement[] */
 parse('<div>text</div>');
 
 // `options.replace`
@@ -39,8 +39,5 @@ parse('<a id="header" href="#">Heading</a>', {
 // $ExpectType DomElement[]
 const dom = htmlToDOM('<div>text</div>');
 
-/* $ExpectType ReactElement<any, string | ((props: any) => ReactElement<any, string | any | (new (props: any) => Component<any, any, any>)> | null) |
-(new (props: any) => Component<any, any, any>)> |
-ReactElement<any, string | ((props: any) => ReactElement<any, string | any | (new (props: any) => Component<any, any, any>)> | null) |
-(new (props: any) => Component<any, any, any>)>[] */
+/* $ExpectType ReactElement | ReactElement[] */
 domToReact(dom);

--- a/test/types/lib/dom-to-react.test.tsx
+++ b/test/types/lib/dom-to-react.test.tsx
@@ -3,10 +3,7 @@ import domToReact from 'html-react-parser/lib/dom-to-react';
 import * as React from 'react';
 import htmlToDOM from 'html-dom-parser';
 
-/* $ExpectType ReactElement<any, string | ((props: any) => ReactElement<any, string | any | (new (props: any) => Component<any, any, any>)> | null) |
-(new (props: any) => Component<any, any, any>)> |
-ReactElement<any, string | ((props: any) => ReactElement<any, string | any | (new (props: any) => Component<any, any, any>)> | null) |
-(new (props: any) => Component<any, any, any>)>[] */
+/* $ExpectType ReactElement | ReactElement[] */
 domToReact(htmlToDOM('<div>text</div>'));
 
 // `options.replace`


### PR DESCRIPTION
## What is the motivation for this pull request?

This makes the library usable for non-React JSX implementations in TypeScript. JSX.Element is defined as React.ReactElement for the 'react' package, and is [overridden by other JSX implementations](https://devblogs.microsoft.com/typescript/announcing-typescript-2-8-rc/). Fixes #145.

## What is the current behavior?

Currently, trying to use html-react-parser with Preact in TS will result in a bunch of type errors.

## What is the new behavior?

* React.ReactElement is replaced with JSX.Element, which aliases to React.ReactElement for the current tests
* The HTMLReactParser return value matches the domToReact return value, since the former returns the output of the latter

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [X] Tests

<!--
Any other comments? Thank you for contributing!
-->
