### PR TITLE
List React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^3.9.3"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15 || ^16"
+    "react": "^0.14 || ^15 || ^16 || ^17"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
## What is the motivation for this pull request?

The library currently does not list React 17 as peer dependency