### PR TITLE
build(rollup): replace rollup plugin uglify with terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^16",
     "rimraf": "^3.0.2",
     "rollup": "^2.12.1",
-    "rollup-plugin-uglify": "^6.0.4",
+    "rollup-plugin-terser": "^7.0.2",
     "standard-version": "5",
     "typescript": "^3.9.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import { uglify } from 'rollup-plugin-uglify';
+import { terser } from 'rollup-plugin-terser';
 
 /**
  * Build rollup config for development (default) or production (minify = true).
@@ -20,7 +20,7 @@ const getConfig = (minify = false) => ({
     name: 'HTMLReactParser',
     sourcemap: true
   },
-  plugins: [commonjs(), resolve({ browser: true }), minify && uglify()]
+  plugins: [commonjs(), resolve({ browser: true }), minify && terser()]
 });
 
 export default [getConfig(), getConfig(true)];


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix [Travis CI build error](https://travis-ci.org/github/remarkablemark/html-react-parser/jobs/739476952) when installing with npm 7:

```sh
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! Found: rollup@2.32.1
npm ERR! node_modules/rollup
npm ERR!   dev rollup@"^2.12.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer rollup@">=0.66.0 <2" from rollup-plugin-uglify@6.0.4
npm ERR! node_modules/rollup-plugin-uglify
npm ERR!   dev rollup-plugin-uglify@"^6.0.4" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

To resolve peerDependencies error and support rollup v2, replace [rollup-plugin-uglify](https://github.com/TrySound/rollup-plugin-uglify) with [rollup-plugin-terser](https://github.com/TrySound/rollup-plugin-terser).

See TrySound/rollup-plugin-uglify#82