### PR TITLE
ci(github): add `size-limit.yml` workflow

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,15 @@
+name: size
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    env:
+      CI_JOB_NUMBER: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "dist/html-react-parser.min.js",
+    "limit": "8 KB"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Demos:
   - [Elements aren't nested correctly](#elements-arent-nested-correctly)
   - [Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of table](#warning-validatedomnesting-whitespace-text-nodes-cannot-appear-as-a-child-of-table)
   - [Don't change case of tags](#dont-change-case-of-tags)
-- [Benchmarks](#benchmarks)
+- [Performance](#performance)
 - [Contributors](#contributors)
   - [Code Contributors](#code-contributors)
   - [Financial Contributors](#financial-contributors)
@@ -410,18 +410,26 @@ parse('<CustomElement>', options); // React.createElement('CustomElement')
 
 See [#62](https://github.com/remarkablemark/html-react-parser/issues/62) and [example](https://repl.it/@remarkablemark/html-react-parser-62).
 
-## Benchmarks
+## Performance
+
+Run benchmark:
 
 ```sh
 $ npm run test:benchmark
 ```
 
-Here's an example output of the benchmarks run on a MacBook Pro 2017:
+Output of benchmark run on MacBook Pro 2017:
 
 ```
 html-to-react - Single x 415,186 ops/sec ±0.92% (85 runs sampled)
 html-to-react - Multiple x 139,780 ops/sec ±2.32% (87 runs sampled)
 html-to-react - Complex x 8,118 ops/sec ±2.99% (82 runs sampled)
+```
+
+Run [Size Limit](https://github.com/ai/size-limit):
+
+```sh
+$ npx size-limit
 ```
 
 ## Contributors

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
+    "@size-limit/preset-big-lib": "^4.9.1",
     "@types/react": "^17.0.0",
     "@typescript-eslint/parser": "^4.9.1",
     "benchmark": "^2.1.4",
@@ -57,6 +58,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.34.2",
     "rollup-plugin-terser": "^7.0.2",
+    "size-limit": "^4.9.1",
     "standard-version": "^9.0.0",
     "typescript": "^4.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): add `size-limit.yml` workflow

## What is the current behavior?

No way to test bundle size or performance.

## What is the new behavior?

Added [Size Limit GitHub Action](https://github.com/marketplace/actions/size-limit-action), which uses [Size Limit](https://github.com/ai/size-limit) to calculate cost of JavaScript bundle for end-users.

The bundle size `limit` is set to `8 KB`.

## Checklist:

- [x] Documentation
