### PR TITLE
fix: escape tags inside of <title> (upgrade html-dom-parser to 1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,23 +314,21 @@ parse('<br>', {
 
 ### htmlparser2
 
-The default [htmlparser2 options](https://github.com/fb55/htmlparser2/wiki/Parser-options) are:
+Along with the default [htmlparser2 options](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-xmlmode), the parser also sets:
 
-```js
+```json
 {
-  decodeEntities: true,
-  lowerCaseAttributeNames: false
+  "lowerCaseAttributeNames": false
 }
 ```
 
 Since [v0.12.0](https://github.com/remarkablemark/html-react-parser/tree/v0.12.0), the htmlparser2 options can be overridden.
 
-The following example enables [`decodeEntities`](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-decodeentities) and [`xmlMode`](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-xmlmode):
+The following example enables [`xmlMode`](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-xmlmode) but disables [`lowerCaseAttributeNames`](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-lowercaseattributenames):
 
 ```js
 parse('<p /><p />', {
   htmlparser2: {
-    decodeEntities: true,
     xmlMode: true
   }
 });

--- a/index.js
+++ b/index.js
@@ -2,8 +2,7 @@ var domToReact = require('./lib/dom-to-react');
 var attributesToProps = require('./lib/attributes-to-props');
 var htmlToDOM = require('html-dom-parser');
 
-// decode HTML entities by default for `htmlparser2`
-var domParserOptions = { decodeEntities: true, lowerCaseAttributeNames: false };
+var domParserOptions = { lowerCaseAttributeNames: false };
 
 /**
  * Converts HTML string to React elements.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dom"
   ],
   "dependencies": {
-    "html-dom-parser": "0.5.0",
+    "html-dom-parser": "1.0.0",
     "react-property": "1.0.1",
     "style-to-js": "1.1.0"
   },

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HTMLReactParser escapes tags inside of <title> 1`] = `
+<title>
+  &lt;em&gt;text&lt;/em&gt;
+</title>
+`;
+
 exports[`HTMLReactParser parses SVG 1`] = `
 <svg
   height="400"

--- a/test/data/html.js
+++ b/test/data/html.js
@@ -13,6 +13,7 @@ module.exports = {
   void: '<link/><meta/><img/><br/><hr/><input/>',
   comment: '<!-- comment -->',
   doctype: '<!DOCTYPE html>',
+  title: '<title><em>text</em></title>',
   customElement:
     '<custom-element class="myClass" custom-attribute="value" style="-o-transition: all .5s; line-height: 1;"></custom-element>'
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,6 +75,10 @@ describe('HTMLReactParser', () => {
     const reactElement = parse('<i>' + encodedEntities + '</i>');
     expect(reactElement.props.children).toBe(decodedEntities);
   });
+
+  it('escapes tags inside of <title>', () => {
+    expect(parse(html.title)).toMatchSnapshot();
+  });
 });
 
 describe('replace option', () => {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: escape tags inside of `<title>`

Fixes #202

## What is the current behavior?

Tags inside of `<title>` are not escaped.

## What is the new behavior?

Tags inside of `<title>` are escaped by upgrading to [html-dom-parser@1.0.0](https://github.com/remarkablemark/html-dom-parser/releases/tag/v1.0.0).

```
 html-dom-parser  0.5.0  →  1.0.0
```

## Checklist:

- [x] Tests
- [x] Documentation
