### PR TITLE
fix(index): include domhandler `Node` in `DOMNode` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import {
   Comment,
   DomHandlerOptions,
   Element,
+  Node,
   ProcessingInstruction,
   Text
 } from 'domhandler';
@@ -15,8 +16,8 @@ import domToReact from './lib/dom-to-react';
 
 export { attributesToProps, domToReact, htmlToDOM };
 export type HTMLParser2Options = ParserOptions & DomHandlerOptions;
-export { Comment, Element, ProcessingInstruction, Text };
-export type DOMNode = Comment | Element | ProcessingInstruction | Text;
+export { Comment, Element, Node, ProcessingInstruction, Text };
+export type DOMNode = Comment | Element | Node | ProcessingInstruction | Text;
 
 export interface HTMLReactParserOptions {
   htmlparser2?: HTMLParser2Options;

--- a/test/types/index.tsx
+++ b/test/types/index.tsx
@@ -39,10 +39,20 @@ parse('<br id="remove">', {
   }
 });
 
-const options: HTMLReactParserOptions = {
+let options: HTMLReactParserOptions;
+
+options = {
   replace: domNode => {
     if (domNode instanceof Element && domNode.attribs.id === 'header') {
       return;
+    }
+  }
+};
+
+options = {
+  replace: domNode => {
+    if (domNode instanceof Element) {
+      return <>{domToReact(domNode.children)}</>;
     }
   }
 };
@@ -76,7 +86,7 @@ parse('<p/><p/>', {
 // $ExpectType string | Element | Element[]
 parse('\t<p>text \r</p>\n', { trim: true });
 
-// $ExpectType DOMNode[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 const domNodes = htmlToDOM('<div>text</div>');
 
 // $ExpectType string | Element | Element[]

--- a/test/types/lib/dom-to-react.tsx
+++ b/test/types/lib/dom-to-react.tsx
@@ -4,7 +4,7 @@ import domToReact from 'html-react-parser/lib/dom-to-react';
 import * as React from 'react';
 import htmlToDOM from 'html-dom-parser';
 
-// $ExpectType DOMNode[]
+// $ExpectType (Comment | Element | ProcessingInstruction | Text)[]
 htmlToDOM('<div>text</div>');
 
 // $ExpectType string | Element | Element[]


### PR DESCRIPTION
Fixes #207

## What is the motivation for this pull request?

fix(index): include domhandler `Node` in `DOMNode` type

## What is the current behavior?

```ts
import {
  Comment,
  DomHandlerOptions,
  Element,
  ProcessingInstruction,
  Text
} from 'domhandler';

export { Comment, Element, ProcessingInstruction, Text };

export type DOMNode = Comment | Element | ProcessingInstruction | Text;
```

## What is the new behavior?

```ts
import {
  Comment,
  DomHandlerOptions,
  Element,
  Node,
  ProcessingInstruction,
  Text
} from 'domhandler';

export { Comment, Element, Node, ProcessingInstruction, Text };

export type DOMNode = Comment | Element | Node | ProcessingInstruction | Text;
```

## Checklist:

- [x] Tests
- [x] Types
