### PR TITLE
test(integration): add tests for UMD bundle and fail build if there are warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm run lint
       - run: npm run lint:dts
       - run: npm run test:ci
-      - run: npm run build
+      - run: npm run test:integration
       - run: npm run benchmark
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "index.mjs",
   "scripts": {
     "benchmark": "node benchmark",
-    "build": "rollup --config",
+    "build": "rollup --config --failAfterWarnings",
     "clean": "rimraf dist",
     "lint": "eslint --ignore-path .gitignore --ignore-pattern /examples/ .",
     "lint:dts": "dtslint .",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run lint && npm run lint:dts && npm run test:ci && npm run clean && npm run build",
     "release": "standard-version --no-verify",
-    "test": "jest --coverage",
+    "test": "jest --coverage --testPathIgnorePatterns test/integration/",
     "test:ci": "npm test -- --ci",
+    "test:integration": "npm run build && jest test/integration/",
     "test:watch": "npm test -- --watch"
   },
   "repository": {

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -1,0 +1,26 @@
+describe.each([
+  ['unminified', '../../dist/html-react-parser'],
+  ['minified', '../../dist/html-react-parser.min']
+])('UMD %s', (_type, path) => {
+  const parse = require(path);
+
+  it('exports the parser', () => {
+    expect(parse).toBeInstanceOf(Function);
+  });
+
+  it('exports default', () => {
+    expect(parse.default).toBeInstanceOf(Function);
+  });
+
+  it('exports domToReact', () => {
+    expect(parse.domToReact).toBeInstanceOf(Function);
+  });
+
+  it('exports htmlToDOM', () => {
+    expect(parse.htmlToDOM).toBeInstanceOf(Function);
+  });
+
+  it('exports attributesToProps', () => {
+    expect(parse.attributesToProps).toBeInstanceOf(Function);
+  });
+});


### PR DESCRIPTION
## What is the motivation for this pull request?

test: add integration tests for UMD bundle and fail build if there are warnings

## What is the current behavior?

- No integration tests for UMD bundle
- Rollup build does not fail if there are warnings

## What is the new behavior?

- Added integration tests for UMD bundle
- Rollup build fails if there are warnings

## Checklist:

- [x] Tests
