### PR TITLE
fix(index): export without const in `index.mjs`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,1 @@
-import HTMLReactParser from './index.js';
-
-export default HTMLReactParser;
-export const { domToReact, htmlToDOM, attributesToProps } = HTMLReactParser;
+export { default, domToReact, htmlToDOM, attributesToProps } from './index.js';


### PR DESCRIPTION
Fixes #214, fixes #213

## What is the motivation for this pull request?

fix(index): export without const in `index.mjs`

## What is the current behavior?

Module bundlers (webpack, rollup) that prioritizes the `module` field in `package.json` is now getting bundling `const` (introduced in #210) because of the syntax:

```js
import HTMLReactParser from './index.js';

export default HTMLReactParser;
export const { domToReact, htmlToDOM, attributesToProps } = HTMLReactParser;
```

This breaks older/legacy browsers like IE11.

## What is the new behavior?

Update `index.mjs` to export without `const`:

```js
export { default, domToReact, htmlToDOM, attributesToProps } from './index.js';
```
