### PR TITLE
fix(index): make sure to export the named exports

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,1 +1,4 @@
-export { default, domToReact, htmlToDOM, attributesToProps } from './index.js';
+import HTMLReactParser from './index.js';
+
+export default HTMLReactParser;
+export var { domToReact, htmlToDOM, attributesToProps } = HTMLReactParser;


### PR DESCRIPTION
Fixes #217

## What is the motivation for this pull request?

fix(index): make sure to export the named exports

## What is the current behavior?

#216 caused a regression where the named exports are not working:

```
./node_modules/html-react-parser/index.mjs
Can't reexport the named export 'attributesToProps' from non EcmaScript module (only default export is available)
```

## What is the new behavior?

Reverted `index.mjs` back to how it was before but replaced `const` with `var`:

```js
import HTMLReactParser from './index.js';

export default HTMLReactParser;
export var { domToReact, htmlToDOM, attributesToProps } = HTMLReactParser;
```
