### PR TITLE
fix(index): refactor ES module from ES6 to ES5 syntax

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,7 @@
 import HTMLReactParser from './index.js';
 
+export var domToReact = HTMLReactParser.domToReact;
+export var htmlToDOM = HTMLReactParser.htmlToDOM;
+export var attributesToProps = HTMLReactParser.attributesToProps;
+
 export default HTMLReactParser;
-export var { domToReact, htmlToDOM, attributesToProps } = HTMLReactParser;


### PR DESCRIPTION
Fixes #222

## What is the motivation for this pull request?

fix(index): refactor ES module from ES6 to ES5 syntax

This is a regression from #220

## What is the current behavior?

The ES module `index.mjs` uses ES6 syntax (object destructuring assignment), which breaks older browsers like IE11.

## What is the new behavior?

`index.mjs` uses ES6 syntax.
