### PR TITLE
fix(package): add domhandler to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dom"
   ],
   "dependencies": {
+    "domhandler": "4.0.0",
     "html-dom-parser": "1.0.0",
     "react-property": "1.0.1",
     "style-to-js": "1.1.0"


### PR DESCRIPTION
added missing dependency for "domhandler": "^4.0.0"

fixes #231

## Checklist:

- [ ] Tests
- [ ] Documentation
- [ ] Types

Explanation can be found in the issue. Only tested the workaround explained in the issue.

