### PR TITLE
fix(attributes-to-props): fix attributes-to-props type `Props`

### DIFF
--- a/lib/attributes-to-props.d.ts
+++ b/lib/attributes-to-props.d.ts
@@ -1,7 +1,10 @@
 // TypeScript Version: 4.1
 
 export type Attributes = Record<string, string>;
-export type Props = Attributes;
+
+export type Props = Record<string, string> & {
+  style: Record<string, string>;
+};
 
 /**
  * Converts HTML/SVG DOM attributes to React props.

--- a/test/types/lib/attributes-to-props.ts
+++ b/test/types/lib/attributes-to-props.ts
@@ -1,0 +1,17 @@
+import attributesToProps, {
+  Attributes,
+  Props
+} from 'html-react-parser/lib/attributes-to-props';
+
+let attributes: Attributes = {};
+
+attributes = {
+  class: 'my-class',
+  style: 'color: #bada55; line-height: 42;'
+};
+
+// $ExpectType Props
+const {
+  className,
+  style: { color, lineHeight }
+} = attributesToProps(attributes);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "index.d.ts",
     "lib/dom-to-react.d.ts",
     "test/types/index.tsx",
+    "test/types/lib/attributes-to-props.ts",
     "test/types/lib/dom-to-react.tsx"
   ]
 }


### PR DESCRIPTION
Fixes #242

## What is the motivation for this pull request?

fix(attributes-to-props): fix attributes-to-props type `Props`

## What is the current behavior?

```ts
type Props = Record<string, string>;
```

## What is the new behavior?

```ts
type Props = Record<string, string> & {
  style: Record<string, string>;
}; 
```

## Checklist:

- [x] Tests
- [x] Types
