### PR TITLE
ci(github): use default Node.js version in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      matrix:
-        node-version: [16]
 
     steps:
       - name: Checkout repository
@@ -15,10 +12,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): use default Node.js version in `build.yml`

## What is the current behavior?

Node.js version is hardcoded.

## What is the new behavior?

Use default Node.js version (LTS).