### PR TITLE
ci(size-limit): increase limit from 8 to 9.23 KB

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "8 KB"
+    "limit": "9.23 KB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable && npm run lint && npm run lint:dts && npm run test:ci && npm run clean && npm run build",
     "release": "standard-version --no-verify",
+    "size-limit": "size-limit",
     "test": "jest --coverage --testPathIgnorePatterns test/integration/",
     "test:ci": "npm test -- --ci",
     "test:module": "node --experimental-modules test/module/index.mjs",


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(size-limit): increase limit from 8 to 9.23 KB

## What is the current behavior?

Size Limit is set at 8 KB and failing with v1.3.0 release

## What is the new behavior?

Increase Size Limit to 9.23 KB