### PR TITLE
perf: upgrade dependency html-dom-parser to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "domhandler": "4.2.2",
-    "html-dom-parser": "1.0.2",
+    "html-dom-parser": "1.0.3",
     "react-property": "2.0.0",
     "style-to-js": "1.1.0"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

Upgrade `html-dom-parser` to [1.0.3](https://github.com/remarkablemark/html-dom-parser/releases/tag/v1.0.3)

```
 html-dom-parser  1.0.2  →  1.0.3
```

See https://github.com/remarkablemark/html-dom-parser/pull/146