### PR TITLE
build(deps): bump domhandler to 4.3.0 and html-dom-parser to 1.0.4

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "9.24 KB"
+    "limit": "10.1 KB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "dom"
   ],
   "dependencies": {
-    "domhandler": "4.2.2",
-    "html-dom-parser": "1.0.3",
+    "domhandler": "4.3.0",
+    "html-dom-parser": "1.0.4",
     "react-property": "2.0.0",
     "style-to-js": "1.1.0"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

build(deps): bump `domhandler` to 4.3.0 and `html-dom-parser` to 1.0.4

Closes #372

```
 domhandler       4.2.2  →  4.3.0
 html-dom-parser  1.0.3  →  1.0.4
```