### PR TITLE
fix: trim only when necessary if trimming is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,16 +351,16 @@ By default, whitespace is preserved:
 parse('<br>\n'); // [React.createElement('br'), '\n']
 ```
 
+However, whitespace that are invalid under certain nodes like `<table>` will be stripped out.
+
+```js
+parse('<table>\n</table>'); // [React.createElement('table')]
+```
+
 To remove whitespace, enable the `trim` option:
 
 ```js
 parse('<br>\n', { trim: true }); // React.createElement('br')
-```
-
-This fixes the warning:
-
-```
-Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <table>. Make sure you don't have any extra whitespace between tags on each line of your source code.
 ```
 
 However, intentional whitespace may be stripped out:
@@ -426,10 +426,6 @@ parse('<div /><div />'); // returns single element instead of array of elements
 ```
 
 See [#158](https://github.com/remarkablemark/html-react-parser/issues/158).
-
-### Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of table
-
-Enable the [trim](#trim) option. See [#155](https://github.com/remarkablemark/html-react-parser/issues/155).
 
 ### Don't change case of tags
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ parse('<p>Hello, World!</p>'); // React.createElement('p', {}, 'Hello, World!')
   - [Parser throws an error](#parser-throws-an-error)
   - [Is SSR supported?](#is-ssr-supported)
   - [Elements aren't nested correctly](#elements-arent-nested-correctly)
-  - [Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of table](#warning-validatedomnesting-whitespace-text-nodes-cannot-appear-as-a-child-of-table)
   - [Don't change case of tags](#dont-change-case-of-tags)
   - [TS Error: Property 'attribs' does not exist on type 'DOMNode'](#ts-error-property-attribs-does-not-exist-on-type-domnode)
   - [Can I enable `trim` for certain elements?](#can-i-enable-trim-for-certain-elements)
@@ -351,10 +350,10 @@ By default, whitespace is preserved:
 parse('<br>\n'); // [React.createElement('br'), '\n']
 ```
 
-However, whitespace that are invalid under certain nodes like `<table>` will be stripped out.
+But certain elements like `<table>` will strip out invalid whitespace:
 
 ```js
-parse('<table>\n</table>'); // [React.createElement('table')]
+parse('<table>\n</table>'); // React.createElement('table')
 ```
 
 To remove whitespace, enable the `trim` option:

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -55,7 +55,7 @@ function domToReact(nodes, options) {
       isWhitespace = !node.data.trim().length;
 
       if (isWhitespace && node.parent && !canTextBeChildOfNode(node.parent)) {
-        // We have a whitespace node that can't be nested in it's parent
+        // We have a whitespace node that can't be nested in its parent
         // so skip it
         continue;
       }
@@ -66,7 +66,7 @@ function domToReact(nodes, options) {
         continue;
       }
 
-      // We have a text node thats not whitespace and it can be nested
+      // We have a text node that's not whitespace and it can be nested
       // in its parent so add it to the results
       result.push(node.data);
       continue;

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -3,6 +3,7 @@ var attributesToProps = require('./attributes-to-props');
 var utilities = require('./utilities');
 
 var setStyleProp = utilities.setStyleProp;
+var canTextBeChildOfNode = utilities.canTextBeChildOfNode;
 
 /**
  * Converts DOM nodes to JSX element(s).
@@ -23,11 +24,11 @@ function domToReact(nodes, options) {
 
   var result = [];
   var node;
+  var isWhitespace;
   var hasReplace = typeof options.replace === 'function';
   var replaceElement;
   var props;
   var children;
-  var data;
   var trim = options.trim;
 
   for (var i = 0, len = nodes.length; i < len; i++) {
@@ -51,15 +52,23 @@ function domToReact(nodes, options) {
     }
 
     if (node.type === 'text') {
-      // if trim option is enabled, skip whitespace text nodes
-      if (trim) {
-        data = node.data.trim();
-        if (data) {
-          result.push(node.data);
-        }
-      } else {
-        result.push(node.data);
+      isWhitespace = !node.data.trim().length;
+
+      if (isWhitespace && node.parent && !canTextBeChildOfNode(node.parent)) {
+        // We have a whitespace node that can't be nested in it's parent
+        // so skip it
+        continue;
       }
+
+      if (trim && isWhitespace) {
+        // Trim is enabled and we have a whitespace node
+        // so skip it
+        continue;
+      }
+
+      // We have a text node thats not whitespace and it can be nested
+      // in its parent so add it to the results
+      result.push(node.data);
       continue;
     }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -107,8 +107,7 @@ var elementsWithNoTextChildren = new Set([
   'table',
   'head',
   'html',
-  'frameset',
-  '#document'
+  'frameset'
 ]);
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -112,7 +112,8 @@ var elementsWithNoTextChildren = new Set([
 ]);
 
 /**
- * Returns True if the the given node can contain text nodes
+ * Checks if the given node can contain text nodes
+ *
  * @param {DomElement} node
  * @returns {boolean}
  */

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -96,9 +96,34 @@ function setStyleProp(style, props) {
  */
 var PRESERVE_CUSTOM_ATTRIBUTES = React.version.split('.')[0] >= 16;
 
+// Taken from
+// https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react-dom/src/client/validateDOMNesting.js#L213
+var elementsWithNoTextChildren = new Set([
+  'tr',
+  'tbody',
+  'thead',
+  'tfoot',
+  'colgroup',
+  'table',
+  'head',
+  'html',
+  'frameset',
+  '#document'
+]);
+
+/**
+ * Returns True if the the given node can contains text nodes
+ * @param {DomElement} node
+ * @returns {boolean}
+ */
+function canTextBeChildOfNode(node) {
+  return !elementsWithNoTextChildren.has(node.name);
+}
+
 module.exports = {
   PRESERVE_CUSTOM_ATTRIBUTES: PRESERVE_CUSTOM_ATTRIBUTES,
   invertObject: invertObject,
   isCustomComponent: isCustomComponent,
-  setStyleProp: setStyleProp
+  setStyleProp: setStyleProp,
+  canTextBeChildOfNode: canTextBeChildOfNode
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -112,7 +112,7 @@ var elementsWithNoTextChildren = new Set([
 ]);
 
 /**
- * Returns True if the the given node can contains text nodes
+ * Returns True if the the given node can contain text nodes
  * @param {DomElement} node
  * @returns {boolean}
  */
@@ -125,5 +125,6 @@ module.exports = {
   invertObject: invertObject,
   isCustomComponent: isCustomComponent,
   setStyleProp: setStyleProp,
-  canTextBeChildOfNode: canTextBeChildOfNode
+  canTextBeChildOfNode: canTextBeChildOfNode,
+  elementsWithNoTextChildren: elementsWithNoTextChildren
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,12 +141,12 @@ describe('trim option', () => {
   it('preserves whitespace text nodes when disabled if valid in parent (default)', () => {
     const html = `<table>
   <tbody>
-    <tr><td>\n</td>\t</tr>\r
+    <tr><td>\n</td><td>&nbsp;</td>\t</tr>\r
   </tbody>
 </table>`;
     const reactElement = parse(html);
     expect(render(reactElement)).toBe(
-      '<table><tbody><tr><td>\n</td></tr></tbody></table>'
+      '<table><tbody><tr><td>\n</td><td>\u00a0</td></tr></tbody></table>'
     );
     expect(reactElement).toMatchInlineSnapshot(`
       <table>
@@ -155,6 +155,9 @@ describe('trim option', () => {
             <td>
               
 
+            </td>
+            <td>
+              \u00a0
             </td>
           </tr>
         </tbody>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,13 +138,16 @@ describe('htmlparser2 option', () => {
 });
 
 describe('trim option', () => {
-  it('preserves whitespace text nodes when disabled (default)', () => {
+  it('preserves whitespace text nodes when disabled if valid in parent (default)', () => {
     const html = `<table>
   <tbody>
+    <tr><td>\n</td>\t</tr>\r
   </tbody>
 </table>`;
     const reactElement = parse(html);
-    expect(render(reactElement)).toBe(html);
+    expect(render(reactElement)).toBe(
+      '<table><tbody><tr><td>\n</td></tr></tbody></table>'
+    );
   });
 
   it('removes whitespace text nodes when enabled', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,6 +148,18 @@ describe('trim option', () => {
     expect(render(reactElement)).toBe(
       '<table><tbody><tr><td>\n</td></tr></tbody></table>'
     );
+    expect(reactElement).toMatchInlineSnapshot(`
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              
+
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `);
   });
 
   it('removes whitespace text nodes when enabled', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,17 +141,20 @@ describe('trim option', () => {
   it('preserves whitespace text nodes when disabled if valid in parent (default)', () => {
     const html = `<table>
   <tbody>
-    <tr><td>\n</td><td>&nbsp;</td>\t</tr>\r
+    <tr><td>hello</td><td>\n</td><td>&nbsp;</td>\t</tr>\r
   </tbody>
 </table>`;
     const reactElement = parse(html);
     expect(render(reactElement)).toBe(
-      '<table><tbody><tr><td>\n</td><td>\u00a0</td></tr></tbody></table>'
+      '<table><tbody><tr><td>hello</td><td>\n</td><td>\u00a0</td></tr></tbody></table>'
     );
     expect(reactElement).toMatchInlineSnapshot(`
       <table>
         <tbody>
           <tr>
+            <td>
+              hello
+            </td>
             <td>
               
 

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -130,7 +130,7 @@ describe('setStyleProp', () => {
 
 describe('canTextBeChildOfNode', () => {
   it.each(Array.from(elementsWithNoTextChildren))(
-    'returns false since text node can not be child of %s',
+    'returns false since text node cannot be child of %s',
     nodeName => {
       const node = {
         name: nodeName

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -3,7 +3,9 @@ const {
   PRESERVE_CUSTOM_ATTRIBUTES,
   invertObject,
   isCustomComponent,
-  setStyleProp
+  setStyleProp,
+  elementsWithNoTextChildren,
+  canTextBeChildOfNode
 } = require('../lib/utilities');
 
 describe('invertObject', () => {
@@ -123,5 +125,24 @@ describe('setStyleProp', () => {
     const props = {};
     expect(setStyleProp(style, props)).toBe(undefined);
     expect(props).toEqual({ style: {} });
+  });
+});
+
+describe('canTextBeChildOfNode', () => {
+  it.each(Array.from(elementsWithNoTextChildren))(
+    'returns false since text node can not be child of %s',
+    nodeName => {
+      const node = {
+        name: nodeName
+      };
+      expect(canTextBeChildOfNode(node)).toBe(false);
+    }
+  );
+
+  it('returns true if text can be child of <td/>', () => {
+    const node = {
+      name: 'td'
+    };
+    expect(canTextBeChildOfNode(node)).toBe(true);
   });
 });


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

Fixes #384

## What is the motivation for this pull request?
Fixes an issue #384 where trimming can lead to inaccurate parsing when nodes have whitespace characters

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
 - if trim is off, whitespace characters trigger reacts validation errors
 - if trim is on, whitespaces are stripped from nodes that can contain white spaces which results in inaccurate parsing
<!-- Please link to the issue (if applicable). -->

## What is the new behavior?
Regardless of the trimming setting, if a text node appears in a node that can contain text nodes eg `<table>`, `<tr>`, it will be removed. If trimming is off, then whitespaces are preserved in nodes that can contain text nodes. 

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
- [x] Types

Looking for approvals before I add to documentation!