### PR TITLE
fix: make reset and submit input types retain value attribs

### DIFF
--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -10,12 +10,18 @@ var utilities = require('./utilities');
 module.exports = function attributesToProps(attributes) {
   attributes = attributes || {};
 
+  var valueOnlyInputs = {
+    reset: true,
+    submit: true
+  };
+
   var attributeName;
   var attributeNameLowerCased;
   var attributeValue;
   var propName;
   var propertyInfo;
   var props = {};
+  var inputIsValueOnly = attributes.type && valueOnlyInputs[attributes.type];
 
   for (attributeName in attributes) {
     attributeValue = attributes[attributeName];
@@ -35,7 +41,10 @@ module.exports = function attributesToProps(attributes) {
 
       // convert attribute to uncontrolled component prop (e.g., `value` to `defaultValue`)
       // https://reactjs.org/docs/uncontrolled-components.html
-      if (propName === 'checked' || propName === 'value') {
+      if (
+        (propName === 'checked' || propName === 'value') &&
+        !inputIsValueOnly
+      ) {
         propName = getPropName('default' + attributeNameLowerCased);
       }
 

--- a/test/attributes-to-props.test.js
+++ b/test/attributes-to-props.test.js
@@ -108,7 +108,15 @@ describe('attributesToProps with HTML attribute', () => {
     [{ checked: '' }, { defaultChecked: true }],
     [{ checked: 'checked' }, { defaultChecked: true }],
     [{ value: '' }, { defaultValue: '' }],
-    [{ value: 'foo' }, { defaultValue: 'foo' }]
+    [{ value: 'foo' }, { defaultValue: 'foo' }],
+    [
+      { value: 'foo', type: 'submit' },
+      { value: 'foo', type: 'submit' }
+    ],
+    [
+      { value: 'foo', type: 'reset' },
+      { value: 'foo', type: 'reset' }
+    ]
   ])(
     'converts form attribute to uncontrolled component property',
     (attributes, props) => {


### PR DESCRIPTION
v1.4.3 changed `value` to `defaultValue` to account for uncontrolled inputs.
However, React seems to ignore the `defaultValue` props for submit and reset
input types. To try:

```
 <input type="submit" defaultValue="foobar" />
```
The above would render

```
<input type="submit" />
```

This PR fixes this by testing `type` attribute in `attributesToProps`

<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

This is a bug fix.

## What is the current behavior?

Converting the html string `<input type=submit value="foo">` would result in the react component `<input type=submit defaultValue="foo">`, which results in `<input type=submit>`.

The same for `type=reset`

## What is the new behavior?

Converting the html string `<input type=submit value="foo">` would result in the react component `<input type=submit value="foo">`, which results in `<input type=submit value="foo">`. Note that the won't raise warnings about controlled [inputs in react](https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react-dom/src/shared/ReactControlledValuePropTypes.js#L8) 

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests


<!--
Any other comments? Thank you for contributing!
-->
