### PR TITLE
build(package): upgrade html-dom-parser from 1.0.4 to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "domhandler": "4.3.0",
-    "html-dom-parser": "1.0.4",
+    "html-dom-parser": "1.1.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.0"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

build(package): upgrade html-dom-parser from 1.0.4 to 1.1.0

See https://github.com/remarkablemark/html-dom-parser/issues/181 and https://github.com/remarkablemark/html-dom-parser/pull/202

## What is the current behavior?

html-dom-parser is 1.0.4

## What is the new behavior?

html-dom-parser is 1.1.0

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)