### PR TITLE
fix: ensure backwards compatibility for html-dom-parser's ES Module

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var htmlToDOM = require('html-dom-parser');
 
 // support backwards compatibility for ES Module
 htmlToDOM =
+  /* istanbul ignore next */
   typeof htmlToDOM.default === 'function' ? htmlToDOM.default : htmlToDOM;
 
 var domParserOptions = { lowerCaseAttributeNames: false };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ var domToReact = require('./lib/dom-to-react');
 var attributesToProps = require('./lib/attributes-to-props');
 var htmlToDOM = require('html-dom-parser');
 
+// support backwards compatibility for ES Module
+htmlToDOM =
+  typeof htmlToDOM.default === 'function' ? htmlToDOM.default : htmlToDOM;
+
 var domParserOptions = { lowerCaseAttributeNames: false };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,18 +6,23 @@ const { render } = require('./helpers');
 describe('module', () => {
   it('exports default', () => {
     expect(parse.default).toBe(parse);
+    expect(parse.default).toBeInstanceOf(Function);
   });
 
   it('exports domToReact', () => {
     expect(parse.domToReact).toBe(require('../lib/dom-to-react'));
+    expect(parse.domToReact).toBeInstanceOf(Function);
   });
 
   it('exports htmlToDOM', () => {
     expect(parse.htmlToDOM).toBe(require('html-dom-parser'));
+    expect(parse.htmlToDOM).toBeInstanceOf(Function);
+    expect(parse.htmlToDOM.default).toBe(undefined);
   });
 
   it('exports attributesToProps', () => {
     expect(parse.attributesToProps).toBe(require('../lib/attributes-to-props'));
+    expect(parse.attributesToProps).toBeInstanceOf(Function);
   });
 });
 


### PR DESCRIPTION
Fixes #445

## What is the motivation for this pull request?

fix: support backwards compatibility for `html-dom-parser`'s ES Module

Regression was caused in [1.4.7](https://github.com/remarkablemark/html-react-parser/releases/tag/v1.4.7). Related to https://github.com/remarkablemark/html-dom-parser/pull/202

## What is the current behavior?

next@10 throws an error:

```
TypeError: htmlToDOM is not a function
```

Note: next@11 and 12 did not have this error

## What is the new behavior?

No error in next@10

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests