### PR TITLE
build: upgrade html-dom-parser to add support for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "domhandler": "4.3.1",
-    "html-dom-parser": "1.1.1",
+    "html-dom-parser": "1.2.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.0"
   },


### PR DESCRIPTION
Closes #511

## What is the motivation for this pull request?

build: upgrade html-dom-parser to add support for react-native

```
html-dom-parser  1.1.1  →  1.2.0
```

See https://github.com/remarkablemark/html-dom-parser/pull/246

## What is the current behavior?

html-dom-parser v1.1.1

## What is the new behavior?

html-dom-parser v1.2.0

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)