### PR TITLE
fix: package.json not defined by exports warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "main": "index.js",
   "module": "index.mjs",
   "exports": {
-    "import": "./index.mjs",
-    "require": "./index.js"
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "benchmark": "node benchmark",


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
Fix warning with package when running react-native

<!-- Is this a feature, bug fix, documentation, etc.? -->

bug fix

## What is the current behavior?
https://github.com/react-native-community/cli/issues/1168 - When running react-native under Node.js 14.x on a project that uses npm modules which specify the new exports field in package.json, react-native will throw a warning of 
`warn Package html-react-parser has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /PATH_TO_CURRENT_PROJECT/node_modules/html-react-parser/package.json`

## What is the new behavior?

Warning no longer appears and package runs correctly

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation - n/a
- [x] Types - n/a

<!--
Any other comments? Thank you for contributing!
-->
