### PR TITLE
fix: export domhandler' Element from it's exports field

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "9.73 KB"
+    "limit": "10.52 KB"
   }
 ]

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function HTMLReactParser(html, options) {
 HTMLReactParser.domToReact = domToReact;
 HTMLReactParser.htmlToDOM = htmlToDOM;
 HTMLReactParser.attributesToProps = attributesToProps;
-HTMLReactParser.Element = require('domhandler/lib/node').Element;
+HTMLReactParser.Element = require('domhandler').Element;
 
 // support CommonJS and ES Modules
 module.exports = HTMLReactParser;


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
Fix error  when running with webpack build

bug fix

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
Got Module Not Found error `Package path ./lib/node is not exported from package ..../node_modules/domhandler`

I found the related issue https://github.com/remarkablemark/html-react-parser/issues/252#issuecomment-896406971  and pr  https://github.com/remarkablemark/html-react-parser/pull/296 , which exports the `Element `type of `domhandler`.

But `domhandler` has used `exports` field,  only exports index files  https://github.com/fb55/domhandler/blob/master/package.json#L13

```
 "exports": {
        "require": "./lib/index.js",
        "import": "./lib/esm/index.js"
    },
```



<!-- Please link to the issue (if applicable). -->

## What is the new behavior?

Require `Element` directly from 'domhandler' index.

Error no longer appears and webpack build runs correctly

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
- [x] Types

<!--
Any other comments? Thank you for contributing!
-->
