### PR TITLE
fix: bump `style-to-js` to 1.1.1; don't capitalize `-ms` vendor prefix

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "10.52 KB"
+    "limit": "10.531 KB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "domhandler": "4.3.1",
     "html-dom-parser": "1.2.0",
     "react-property": "2.0.0",
-    "style-to-js": "1.1.0"
+    "style-to-js": "1.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "17.0.1",

--- a/test/attributes-to-props.test.js
+++ b/test/attributes-to-props.test.js
@@ -253,19 +253,21 @@ describe('attributesToProps with style attribute', () => {
         color: #f00; font-size: 42px; z-index: -1; -webkit-border-top-right-radius: 10rem; background: url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif);
         /* display: block;  */
         --custom-property: #f00;
-        border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px'
+        border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px;
+        -ms-transform: none;
       `;
     expect(attributesToProps({ style })).toMatchInlineSnapshot(`
       Object {
         "style": Object {
           "--custom-property": "#f00",
-          "MozBorderRadiusBottomleft": "20px'",
+          "MozBorderRadiusBottomleft": "20px",
           "WebkitBorderTopRightRadius": "10rem",
           "background": "url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)",
           "borderBottomLeftRadius": "1em",
           "borderRightStyle": "solid",
           "color": "#f00",
           "fontSize": "42px",
+          "msTransform": "none",
           "zIndex": "-1",
         },
       }


### PR DESCRIPTION
Relates to https://github.com/remarkablemark/style-to-js/issues/2, https://github.com/remarkablemark/style-to-js/pull/3

## What is the motivation for this pull request?

fix: don't capitalize `-ms` vendor prefix

## What is the current behavior?

[style-to-js@1.1.0](https://github.com/remarkablemark/style-to-js/releases/tag/v1.1.0) capitalizes `-ms` vendor prefix

## What is the new behavior?

[style-to-js@1.1.1](https://github.com/remarkablemark/style-to-js/releases/tag/v1.1.1) doesn't capitalize `-ms` vendor prefix

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests