### PR TITLE
build(package): bump html-dom-parser from 1.2.0 to 2.0.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ parse('<p>Hello, World!</p>'); // React.createElement('p', {}, 'Hello, World!')
   - [htmlparser2](#htmlparser2)
   - [trim](#trim)
 - [Migration](#migration)
+  - [v2.0.0](#v200)
   - [v1.0.0](#v100)
 - [FAQ](#faq)
   - [Is this XSS safe?](#is-this-xss-safe)
@@ -369,6 +370,10 @@ parse('<p> </p>', { trim: true }); // React.createElement('p')
 ```
 
 ## Migration
+
+### v2.0.0
+
+Since [v2.0.0](https://github.com/remarkablemark/html-react-parser/releases/tag/v2.0.0), Internet Explorer (IE) is no longer supported.
 
 ### v1.0.0
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "4.3.1",
-    "html-dom-parser": "1.2.0",
+    "html-dom-parser": "2.0.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: drop Internet Explorer (IE) support

Internet Explorer has been retired on 2022-06-15

See https://github.com/remarkablemark/html-dom-parser/pull/302

## What is the current behavior?

IE11 is still supported

## What is the new behavior?

IE is no longer supported

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Documentation