### PR TITLE
build: upgrade domhandler to 5.0.3 and html-dom-parser to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ parse('<p>Hello, World!</p>'); // React.createElement('p', {}, 'Hello, World!')
   - [htmlparser2](#htmlparser2)
   - [trim](#trim)
 - [Migration](#migration)
+  - [v3.0.0](#v300)
   - [v2.0.0](#v200)
   - [v1.0.0](#v100)
 - [FAQ](#faq)
@@ -370,6 +371,10 @@ parse('<p> </p>', { trim: true }); // React.createElement('p')
 ```
 
 ## Migration
+
+### v3.0.0
+
+[domhandler](https://github.com/fb55/domhandler) has been upgraded to v5 so some [parser options](https://github.com/fb55/htmlparser2/wiki/Parser-options) like `normalizeWhitespace` have been removed.
 
 ### v2.0.0
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "dom"
   ],
   "dependencies": {
-    "domhandler": "4.3.1",
-    "html-dom-parser": "2.0.0",
+    "domhandler": "5.0.3",
+    "html-dom-parser": "3.0.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },

--- a/test/types/index.tsx
+++ b/test/types/index.tsx
@@ -86,7 +86,7 @@ parse('<p/><p/>', {
 // $ExpectType string | Element | Element[]
 parse('\t<p>text \r</p>\n', { trim: true });
 
-// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
+// $ExpectType (Element | Text | Comment | ProcessingInstruction)[]
 const domNodes = htmlToDOM('<div>text</div>');
 
 // $ExpectType string | Element | Element[]

--- a/test/types/lib/dom-to-react.tsx
+++ b/test/types/lib/dom-to-react.tsx
@@ -4,7 +4,7 @@ import domToReact from 'html-react-parser/lib/dom-to-react';
 import * as React from 'react';
 import htmlToDOM from 'html-dom-parser';
 
-// $ExpectType (Text | Comment | ProcessingInstruction | Element)[]
+// $ExpectType (Element | Text | Comment | ProcessingInstruction)[]
 htmlToDOM('<div>text</div>');
 
 // $ExpectType string | Element | Element[]


### PR DESCRIPTION
Relates to https://github.com/remarkablemark/html-dom-parser/pull/314

## What is the motivation for this pull request?

BREAKING CHANGE: bump `domhandler` from 4 to 5 and `html-dom-parser` from 2 to 3

```
 domhandler       4.3.1  →  5.0.3
 html-dom-parser  2.0.0  →  3.0.0
```

## What is the current behavior?

- domhandler@4.3.1
- html-dom-parser@2.0.0

## What is the new behavior?

- domhandler@5.0.3
- html-dom-parser@3.0.0

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Types
- [x] Documentation