### PR TITLE
fix: parse head/body with newline correctly (bump html-dom-parser)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.0.0",
+    "html-dom-parser": "3.0.1",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },


### PR DESCRIPTION
Fixes #624

## What is the motivation for this pull request?

- fix: parse head/body with newline correctly
- build(package): bump html-dom-parser from 3.0.0 to 3.0.1

## What is the current behavior?

- html-dom-parser@3.0.0
- head/body elements with newline are not parsed correctly

## What is the new behavior?

- html-dom-parser@3.0.1
- head/body elements with newline are parsed correctly

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)