### PR TITLE
build(package): bump html-dom-parser from 3.0.1 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.0.1",
+    "html-dom-parser": "3.1.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,7 @@ describe('module', () => {
   it('exports htmlToDOM', () => {
     expect(parse.htmlToDOM).toBe(require('html-dom-parser'));
     expect(parse.htmlToDOM).toBeInstanceOf(Function);
-    expect(parse.htmlToDOM.default).toBe(undefined);
+    expect(parse.htmlToDOM.default).toBe(parse.htmlToDOM);
   });
 
   it('exports attributesToProps', () => {


### PR DESCRIPTION
## What is the motivation for this pull request?

build(package): bump html-dom-parser from 3.0.1 to 3.1.0

Closes #655

## What is the current behavior?

html-dom-parser@3.0.1

## What is the new behavior?

[html-dom-parser@3.1.0](https://github.com/remarkablemark/html-dom-parser/pull/332#issuecomment-1216102243)

See https://github.com/remarkablemark/html-dom-parser/pull/331

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
- [ ] Types