### PR TITLE
fix(package): upgrade html-dom-parser to fix client ES Module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.0",
+    "html-dom-parser": "3.1.1",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): upgrade html-dom-parser to fix client ES Module export

See https://github.com/remarkablemark/html-dom-parser/pull/335

## What is the current behavior?

```
ReferenceError: module is not defined
```

## What is the new behavior?

No ReferenceError

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
- [ ] Types