### PR TITLE
fix(package): upgrade html-dom-parser to fix client ES Module import

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.1",
+    "html-dom-parser": "3.1.2",
     "react-property": "2.0.0",
     "style-to-js": "1.1.1"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): upgrade html-dom-parser to fix client ES Module import

Fixes #662

Relates to https://github.com/remarkablemark/html-dom-parser/issues/337

## What is the current behavior?

Error in html-dom-parser@3.1.1:

```
error - /app/node_modules/html-dom-parser/lib/client/html-to-dom.mjs
Can't import the named export 'formatDOM' from non EcmaScript module (only default export is available)
```

## What is the new behavior?

No error in [html-dom-parser@3.1.2](https://github.com/remarkablemark/html-dom-parser/pull/339#issuecomment-1223371393)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
- [ ] Types