### PR TITLE
fix(index): export domhandler classes

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "10.531 KB"
+    "limit": "10.524 KB"
   }
 ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ import domToReact from './lib/dom-to-react';
 
 export { attributesToProps, domToReact, htmlToDOM };
 export type HTMLParser2Options = ParserOptions & DomHandlerOptions;
-export { Comment, Element, Node, ProcessingInstruction, Text };
+export { Comment, Element, ProcessingInstruction, Text };
 export type DOMNode = Comment | Element | Node | ProcessingInstruction | Text;
 
 export interface HTMLReactParserOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,16 @@
 // TypeScript Version: 4.7
+/* eslint-disable no-undef, no-unused-vars */
 
-import { ParserOptions } from 'htmlparser2';
 import {
   Comment,
-  DomHandlerOptions,
   Element,
   Node,
   ProcessingInstruction,
-  Text
+  Text,
+  type DomHandlerOptions
 } from 'domhandler';
 import htmlToDOM from 'html-dom-parser';
+import { ParserOptions } from 'htmlparser2';
 
 import attributesToProps from './lib/attributes-to-props';
 import domToReact from './lib/dom-to-react';

--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ HTMLReactParser.attributesToProps = attributesToProps;
 // domhandler
 HTMLReactParser.Comment = domhandler.Comment;
 HTMLReactParser.Element = domhandler.Element;
-HTMLReactParser.Node = domhandler.Node;
 HTMLReactParser.ProcessingInstruction = domhandler.ProcessingInstruction;
 HTMLReactParser.Text = domhandler.Text;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-var domToReact = require('./lib/dom-to-react');
-var attributesToProps = require('./lib/attributes-to-props');
+var domhandler = require('domhandler');
 var htmlToDOM = require('html-dom-parser');
+
+var attributesToProps = require('./lib/attributes-to-props');
+var domToReact = require('./lib/dom-to-react');
 
 // support backwards compatibility for ES Module
 htmlToDOM =
@@ -36,7 +38,13 @@ function HTMLReactParser(html, options) {
 HTMLReactParser.domToReact = domToReact;
 HTMLReactParser.htmlToDOM = htmlToDOM;
 HTMLReactParser.attributesToProps = attributesToProps;
-HTMLReactParser.Element = require('domhandler').Element;
+
+// domhandler
+HTMLReactParser.Comment = domhandler.Comment;
+HTMLReactParser.Element = domhandler.Element;
+HTMLReactParser.Node = domhandler.Node;
+HTMLReactParser.ProcessingInstruction = domhandler.ProcessingInstruction;
+HTMLReactParser.Text = domhandler.Text;
 
 // support CommonJS and ES Modules
 module.exports = HTMLReactParser;

--- a/index.mjs
+++ b/index.mjs
@@ -7,7 +7,6 @@ export var attributesToProps = HTMLReactParser.attributesToProps;
 // domhandler
 export var Comment = HTMLReactParser.Comment;
 export var Element = HTMLReactParser.Element;
-export var Node = HTMLReactParser.Node;
 export var ProcessingInstruction = HTMLReactParser.ProcessingInstruction;
 export var Text = HTMLReactParser.Text;
 

--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,12 @@ import HTMLReactParser from './index.js';
 export var domToReact = HTMLReactParser.domToReact;
 export var htmlToDOM = HTMLReactParser.htmlToDOM;
 export var attributesToProps = HTMLReactParser.attributesToProps;
+
+// domhandler
+export var Comment = HTMLReactParser.Comment;
 export var Element = HTMLReactParser.Element;
+export var Node = HTMLReactParser.Node;
+export var ProcessingInstruction = HTMLReactParser.ProcessingInstruction;
+export var Text = HTMLReactParser.Text;
 
 export default HTMLReactParser;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,7 +27,7 @@ describe('module', () => {
   });
 
   describe('domhandler', () => {
-    it.each(['Comment', 'Element', 'Node', 'ProcessingInstruction', 'Text'])(
+    it.each(['Comment', 'Element', 'ProcessingInstruction', 'Text'])(
       'exports %s',
       name => {
         expect(parse[name]).toBeInstanceOf(Function);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const domhandler = require('domhandler');
 const parse = require('..');
 const { html, svg } = require('./data');
 const { render } = require('./helpers');
@@ -23,6 +24,16 @@ describe('module', () => {
   it('exports attributesToProps', () => {
     expect(parse.attributesToProps).toBe(require('../lib/attributes-to-props'));
     expect(parse.attributesToProps).toBeInstanceOf(Function);
+  });
+
+  describe('domhandler', () => {
+    it.each(['Comment', 'Element', 'Node', 'ProcessingInstruction', 'Text'])(
+      'exports %s',
+      name => {
+        expect(parse[name]).toBeInstanceOf(Function);
+        expect(parse[name]).toBe(domhandler[name]);
+      }
+    );
   });
 });
 

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -22,7 +22,7 @@ describe.each([
   });
 
   describe('domhandler', () => {
-    it.each(['Comment', 'Element', 'Node', 'ProcessingInstruction', 'Text'])(
+    it.each(['Comment', 'Element', 'ProcessingInstruction', 'Text'])(
       'exports %s',
       name => {
         expect(parse[name]).toBeInstanceOf(Function);

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -1,10 +1,10 @@
 describe.each([
-  ['unminified', '../../dist/html-react-parser'],
-  ['minified', '../../dist/html-react-parser.min']
+  ['minified', '../../dist/html-react-parser.min'],
+  ['unminified', '../../dist/html-react-parser']
 ])('UMD %s', (_type, path) => {
   const parse = require(path);
 
-  it('exports the parser', () => {
+  it('exports parser', () => {
     expect(parse).toBeInstanceOf(Function);
   });
 
@@ -12,15 +12,21 @@ describe.each([
     expect(parse.default).toBeInstanceOf(Function);
   });
 
-  it('exports domToReact', () => {
-    expect(parse.domToReact).toBeInstanceOf(Function);
+  describe('internal', () => {
+    it.each(['attributesToProps', 'domToReact', 'htmlToDOM'])(
+      'exports %s',
+      name => {
+        expect(parse[name]).toBeInstanceOf(Function);
+      }
+    );
   });
 
-  it('exports htmlToDOM', () => {
-    expect(parse.htmlToDOM).toBeInstanceOf(Function);
-  });
-
-  it('exports attributesToProps', () => {
-    expect(parse.attributesToProps).toBeInstanceOf(Function);
+  describe('domhandler', () => {
+    it.each(['Comment', 'Element', 'Node', 'ProcessingInstruction', 'Text'])(
+      'exports %s',
+      name => {
+        expect(parse[name]).toBeInstanceOf(Function);
+      }
+    );
   });
 });

--- a/test/module/index.mjs
+++ b/test/module/index.mjs
@@ -1,10 +1,22 @@
 import assert from 'assert';
 import parse, {
+  attributesToProps,
   domToReact,
-  htmlToDOM,
-  attributesToProps
+  htmlToDOM
+} from '../../index.mjs';
+import {
+  Comment,
+  Element,
+  Node,
+  ProcessingInstruction,
+  Text
 } from '../../index.mjs';
 
 [parse, domToReact, htmlToDOM, attributesToProps].forEach(func => {
+  assert.strictEqual(typeof func, 'function');
+});
+
+// domhandler
+[Comment, Element, Node, ProcessingInstruction, Text].forEach(func => {
   assert.strictEqual(typeof func, 'function');
 });

--- a/test/module/index.mjs
+++ b/test/module/index.mjs
@@ -4,19 +4,13 @@ import parse, {
   domToReact,
   htmlToDOM
 } from '../../index.mjs';
-import {
-  Comment,
-  Element,
-  Node,
-  ProcessingInstruction,
-  Text
-} from '../../index.mjs';
+import { Comment, Element, ProcessingInstruction, Text } from '../../index.mjs';
 
 [parse, domToReact, htmlToDOM, attributesToProps].forEach(func => {
   assert.strictEqual(typeof func, 'function');
 });
 
 // domhandler
-[Comment, Element, Node, ProcessingInstruction, Text].forEach(func => {
+[Comment, Element, ProcessingInstruction, Text].forEach(func => {
   assert.strictEqual(typeof func, 'function');
 });


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(index): export domhandler classes

Fixes #777

## What is the current behavior?

Only `domhandler` class Element is exported

## What is the new behavior?

Export additional `domhandler` classes:

- Comment
- ProcessingInstruction
- Text

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
- [ ] Types