### PR TITLE
fix(package): include types in exports to support TypeScript ESM node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "index.mjs",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "domhandler": "5.0.3",
     "html-dom-parser": "3.1.2",
     "react-property": "2.0.0",
-    "style-to-js": "1.1.2"
+    "style-to-js": "1.1.3"
   },
   "devDependencies": {
     "@commitlint/cli": "17.4.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.2",
+    "html-dom-parser": "3.1.3",
     "react-property": "2.0.0",
     "style-to-js": "1.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

- fix(package): include types in exports to support TypeScript ESM node16
- build(package): bump style-to-js from 1.1.2 to 1.1.3 
- build(package): bump html-dom-parser from 3.1.2 to 3.1.3 

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types