### PR TITLE
fix: upgrade `html-dom-parser` to 3.1.4 in order to fix template parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.3",
+    "html-dom-parser": "3.1.4",
     "react-property": "2.0.0",
     "style-to-js": "1.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

Bump html-dom-parser from 3.1.3 to 3.1.4 in order to fix template parsing

Fixes #849

## What is the current behavior?

Unable to parse template childNodes

## What is the new behavior?

Template children parsed correctly

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types