### PR TITLE
fix(package): bump html-dom-parser@3.1.5 to fix formatDOM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.4",
+    "html-dom-parser": "3.1.5",
     "react-property": "2.0.0",
     "style-to-js": "1.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #855

## What is the current behavior?

Parse error:

```js
import parse from 'html-react-parser';

parse('<meta name="author" content="John Doe Mason" />');
```

```
TypeError: Cannot read properties of undefined (reading 'length')
 at formatDOM (lib/client/utilities.js)
```

## What is the new behavior?

No error

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types