### PR TITLE
fix: bump html-dom-parser to 3.1.6 to fix feGaussianBlur misspelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.5",
+    "html-dom-parser": "3.1.6",
     "react-property": "2.0.0",
     "style-to-js": "1.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: bump html-dom-parser to 3.1.6 to fix feGaussianBlur misspelling

Fixes #734

Relates to #429 and #430

## What is the current behavior?

```
feGaussainBlur
```

## What is the new behavior?

```
feGaussianBlur
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)