### PR TITLE
fix(types): fix `Type error: ',' expected.` in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 4.7
+// TypeScript Version: 5.0
 /* eslint-disable no-undef, no-unused-vars */
 
 import {
@@ -6,9 +6,9 @@ import {
   Element,
   Node,
   ProcessingInstruction,
-  Text,
-  type DomHandlerOptions
+  Text
 } from 'domhandler';
+import type { DomHandlerOptions } from 'domhandler';
 import htmlToDOM from 'html-dom-parser';
 import { ParserOptions } from 'htmlparser2';
 

--- a/lib/attributes-to-props.d.ts
+++ b/lib/attributes-to-props.d.ts
@@ -1,4 +1,5 @@
-// TypeScript Version: 4.7
+// TypeScript Version: 5.0
+/* eslint-disable no-unused-vars */
 
 export type Attributes = Record<string, string>;
 

--- a/lib/dom-to-react.d.ts
+++ b/lib/dom-to-react.d.ts
@@ -1,4 +1,5 @@
-// TypeScript Version: 4.7
+// TypeScript Version: 5.0
+/* eslint-disable no-undef, no-unused-vars */
 
 import { DOMNode, HTMLReactParserOptions } from '..';
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-duplicate-imports": false
+  }
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(types): fix `Type error: ',' expected.` in index.d.ts

Fixes #871

## What is the current behavior?

Some TypeScript users are getting the error:

```
../../node_modules/html-react-parser/index.d.ts:10:8
Type error: ',' expected.
```

This is caused by module and type imports from 'domhandler' being combined into one.

## What is the new behavior?

Separated module and type imports.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [x] Types