### PR TITLE
docs(readme): fix 2 typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The reason why your HTML attributes aren't getting called is because [inline eve
 
 ### Parser throws an error
 
-If the parser throws an erorr, check if your arguments are valid. See ["Does invalid HTML get sanitized?"](#does-invalid-html-get-sanitized).
+If the parser throws an error, check if your arguments are valid. See ["Does invalid HTML get sanitized?"](#does-invalid-html-get-sanitized).
 
 ### Is SSR supported?
 
@@ -464,7 +464,7 @@ See [#62](https://github.com/remarkablemark/html-react-parser/issues/62) and [ex
 
 ### TS Error: Property 'attribs' does not exist on type 'DOMNode'
 
-The TypeScript error occurs because `DOMNode` needs be an instance of domhandler's `Element`. See [migration](#migration) or [#199](https://github.com/remarkablemark/html-react-parser/issues/199).
+The TypeScript error occurs because `DOMNode` needs to be an instance of domhandler's `Element`. See [migration](#migration) or [#199](https://github.com/remarkablemark/html-react-parser/issues/199).
 
 ### Can I enable `trim` for certain elements?
 


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

To fix a "erorr" typo and sentence with "to be" in README.md I found while reading the docs.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->

It's my first contribution to open-source; I hope it helps! 😄 