### PR TITLE
build(deps): bump html-dom-parser from 3.1.7 to 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ parse('<p>Hello, World!</p>'); // React.createElement('p', {}, 'Hello, World!')
   - [htmlparser2](#htmlparser2)
   - [trim](#trim)
 - [Migration](#migration)
-  - [v3.0.0](#v300)
-  - [v2.0.0](#v200)
-  - [v1.0.0](#v100)
+  - [v4](#v4)
+  - [v3](#v3)
+  - [v2](#v2)
+  - [v1](#v1)
 - [FAQ](#faq)
   - [Is this XSS safe?](#is-this-xss-safe)
   - [Does invalid HTML get sanitized?](#does-invalid-html-get-sanitized)
@@ -376,17 +377,21 @@ parse('<p> </p>', { trim: true }); // React.createElement('p')
 
 ## Migration
 
-### v3.0.0
+### v4
+
+[htmlparser2](https://github.com/fb55/htmlparser2) has been upgraded to [v9](https://github.com/fb55/htmlparser2/releases/tag/v9.0.0).
+
+### v3
 
 [domhandler](https://github.com/fb55/domhandler) has been upgraded to v5 so some [parser options](https://github.com/fb55/htmlparser2/wiki/Parser-options) like `normalizeWhitespace` have been removed.
 
-Also, it's recommended to upgrade to the latest version of [typescript](https://www.npmjs.com/package/typescript).
+Also, it's recommended to upgrade to the latest version of [TypeScript](https://www.npmjs.com/package/typescript).
 
-### v2.0.0
+### v2
 
 Since [v2.0.0](https://github.com/remarkablemark/html-react-parser/releases/tag/v2.0.0), Internet Explorer (IE) is no longer supported.
 
-### v1.0.0
+### v1
 
 TypeScript projects will need to update the types in [v1.0.0](https://github.com/remarkablemark/html-react-parser/releases/tag/v1.0.0).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "3.1.7",
+        "html-dom-parser": "4.0.0",
         "react-property": "2.0.0",
         "style-to-js": "1.1.3"
       },
@@ -3485,7 +3485,8 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -3531,7 +3532,8 @@
     },
     "node_modules/domutils": {
       "version": "3.1.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -5092,11 +5094,12 @@
       "license": "ISC"
     },
     "node_modules/html-dom-parser": {
-      "version": "3.1.7",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
+      "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
       "dependencies": {
         "domhandler": "5.0.3",
-        "htmlparser2": "8.0.2"
+        "htmlparser2": "9.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -5116,7 +5119,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -5124,12 +5129,11 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -12353,6 +12357,8 @@
     },
     "dom-serializer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -12377,6 +12383,8 @@
     },
     "domutils": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -13407,10 +13415,12 @@
       }
     },
     "html-dom-parser": {
-      "version": "3.1.7",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
+      "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
       "requires": {
         "domhandler": "5.0.3",
-        "htmlparser2": "8.0.2"
+        "htmlparser2": "9.0.0"
       }
     },
     "html-encoding-sniffer": {
@@ -13425,12 +13435,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "8.0.2",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "3.1.7",
+    "html-dom-parser": "4.0.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.3"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: bump html-dom-parser from 3.1.7 to 4.0.0

Closes https://github.com/remarkablemark/html-react-parser/pull/941

https://github.com/remarkablemark/html-dom-parser/releases/tag/v4.0.0

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation
- [ ] Types