### PR TITLE
feat: export lib files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
+    "./lib/*": {
+      "types": "./lib/*.d.ts",
+      "default": "./lib/*.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
This exposes the lib files, so `domToReact` can be imported without importing all of `domhandler`, which reduces bundle size.

It also exposes `attributesToProps`, which is useful (at least in my project)

You can import like `import domToReact from 'html-react-parser/dom-to-react'` and `import attributesToProps from 'html-react-parser/attributes-to-props'`

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [x] Types

<!--
Any other comments? Thank you for contributing!
-->
