### PR TITLE
fix(utilities): remove PRESERVE_CUSTOM_ATTRIBUTES

### DIFF
--- a/lib/attributes-to-props.js
+++ b/lib/attributes-to-props.js
@@ -69,10 +69,7 @@ module.exports = function attributesToProps(attributes, nodeName) {
       continue;
     }
 
-    // preserve custom attribute if React >=16
-    if (utilities.PRESERVE_CUSTOM_ATTRIBUTES) {
-      props[attributeName] = attributeValue;
-    }
+    props[attributeName] = attributeValue;
   }
 
   // transform inline style to object
@@ -85,7 +82,7 @@ module.exports = function attributesToProps(attributes, nodeName) {
  * Gets prop name from lowercased attribute name.
  *
  * @param {string} attributeName - Lowercased attribute name.
- * @returns - Prop name.
+ * @returns {string} - Prop name.
  */
 function getPropName(attributeName) {
   return reactProperty.possibleStandardNames[attributeName];

--- a/lib/dom-to-react.js
+++ b/lib/dom-to-react.js
@@ -128,13 +128,11 @@ function domToReact(nodes, options) {
  * Web Components should not have their attributes transformed except for `style`.
  *
  * @param {DomElement} node
- * @returns - Whether node attributes should be converted to props.
+ * @returns {boolean} - Whether node attributes should be converted to props.
  */
 function skipAttributesToProps(node) {
   return (
-    utilities.PRESERVE_CUSTOM_ATTRIBUTES &&
-    node.type === 'tag' &&
-    utilities.isCustomComponent(node.name, node.attribs)
+    node.type === 'tag' && utilities.isCustomComponent(node.name, node.attribs)
   );
 }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,4 +1,3 @@
-var React = require('react');
 var styleToJS = require('style-to-js').default;
 
 /**
@@ -90,12 +89,6 @@ function setStyleProp(style, props) {
   }
 }
 
-/**
- * @constant {boolean}
- * @see {@link https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html}
- */
-var PRESERVE_CUSTOM_ATTRIBUTES = React.version.split('.')[0] >= 16;
-
 // Taken from
 // https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react-dom/src/client/validateDOMNesting.js#L213
 var ELEMENTS_WITH_NO_TEXT_CHILDREN = new Set([
@@ -131,7 +124,6 @@ function returnFirstArg(arg) {
 }
 
 module.exports = {
-  PRESERVE_CUSTOM_ATTRIBUTES: PRESERVE_CUSTOM_ATTRIBUTES,
   ELEMENTS_WITH_NO_TEXT_CHILDREN: ELEMENTS_WITH_NO_TEXT_CHILDREN,
   invertObject: invertObject,
   isCustomComponent: isCustomComponent,

--- a/test/attributes-to-props.test.js
+++ b/test/attributes-to-props.test.js
@@ -1,5 +1,4 @@
 const attributesToProps = require('../lib/attributes-to-props');
-const utilities = require('../lib/utilities');
 
 it('returns empty object is argument is undefined', () => {
   expect(attributesToProps()).toEqual({});
@@ -334,25 +333,5 @@ describe('attributesToProps with custom attribute', () => {
         "valueOf": "",
       }
     `);
-  });
-});
-
-describe('utilities.PRESERVE_CUSTOM_ATTRIBUTES=false', () => {
-  const { PRESERVE_CUSTOM_ATTRIBUTES } = utilities;
-  const emptyProps = {};
-
-  beforeAll(() => {
-    utilities.PRESERVE_CUSTOM_ATTRIBUTES = false;
-  });
-
-  afterAll(() => {
-    utilities.PRESERVE_CUSTOM_ATTRIBUTES = PRESERVE_CUSTOM_ATTRIBUTES;
-  });
-
-  it('omits unknown attributes', () => {
-    const attributes = {
-      unknownAttribute: 'someValue'
-    };
-    expect(attributesToProps(attributes)).toEqual(emptyProps);
   });
 });

--- a/test/dom-to-react.test.js
+++ b/test/dom-to-react.test.js
@@ -2,7 +2,6 @@ const React = require('react');
 const htmlToDOM = require('html-dom-parser');
 
 const domToReact = require('../lib/dom-to-react');
-const utilities = require('../lib/utilities');
 
 const { render } = require('./helpers');
 const { html, svg } = require('./data');
@@ -251,33 +250,6 @@ describe('domToReact', () => {
         <custom-element
           class="myClass"
           custom-attribute="value"
-          style={
-            {
-              "OTransition": "all .5s",
-              "lineHeight": "1",
-            }
-          }
-        />
-      `);
-    });
-  });
-
-  describe('when React <16', () => {
-    const { PRESERVE_CUSTOM_ATTRIBUTES } = utilities;
-
-    beforeAll(() => {
-      utilities.PRESERVE_CUSTOM_ATTRIBUTES = false;
-    });
-
-    afterAll(() => {
-      utilities.PRESERVE_CUSTOM_ATTRIBUTES = PRESERVE_CUSTOM_ATTRIBUTES;
-    });
-
-    it('removes unknown attributes', () => {
-      const reactElement = domToReact(htmlToDOM(html.customElement));
-      expect(reactElement).toMatchInlineSnapshot(`
-        <custom-element
-          className="myClass"
           style={
             {
               "OTransition": "all .5s",

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -1,6 +1,4 @@
-const React = require('react');
 const {
-  PRESERVE_CUSTOM_ATTRIBUTES,
   ELEMENTS_WITH_NO_TEXT_CHILDREN,
   invertObject,
   isCustomComponent,
@@ -83,15 +81,6 @@ describe('isCustomComponent', () => {
 
   it('returns true if the props contains an `is` key', () => {
     expect(isCustomComponent('button', { is: 'custom-button' })).toBe(true);
-  });
-});
-
-describe('PRESERVE_CUSTOM_ATTRIBUTES', () => {
-  const isReactGreaterThan15 =
-    parseInt(React.version.match(/^\d./)[0], 10) >= 16;
-
-  it(`is ${isReactGreaterThan15} when React.version="${React.version}"`, () => {
-    expect(PRESERVE_CUSTOM_ATTRIBUTES).toBe(isReactGreaterThan15);
   });
 });
 


### PR DESCRIPTION
## What is the motivation for this pull request?

Hello 👋 @remarkablemark 

I've looked at this code and have one comment.

If I look at the `package.json` of the current `html-react-parser`, the version of react is `18.2.0`.

So, `PRESERVE_CUSTOM_ATTRIBUTES` is expected to always be `true`, we don't need to check that value.

My guess is that this is legacy code from the past and shouldn't be a problem to remove. 

What do you think? If there's any history I'm not aware of, please let me know. 🙏

## What is the current behavior?
There is no change in behavior.

## What is the new behavior?
There is no change in behavior.


## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
- [x] Types