### PR TITLE
build(package): bump html-dom-parser from 4.0.1 to 5.0.0

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "dist/html-react-parser.min.js",
-    "limit": "10.6 KB"
+    "limit": "10.68 KB"
   }
 ]

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var domhandler = require('domhandler');
-var htmlToDOM = require('html-dom-parser');
+var htmlToDOM = require('html-dom-parser').default;
 
 var attributesToProps = require('./lib/attributes-to-props');
 var domToReact = require('./lib/dom-to-react');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "4.0.1",
+        "html-dom-parser": "5.0.0",
         "react-property": "2.0.0",
         "style-to-js": "1.1.4"
       },
@@ -6164,9 +6164,9 @@
       "license": "ISC"
     },
     "node_modules/html-dom-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.1.tgz",
-      "integrity": "sha512-YADpM4AxP/W4Kyea3Aonmwz64pwlijbXpKHaNwd0ipK/OzCOamI0a24L6nh60uwHmcpD7wC3xvL9unWCPk7tiQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.0.tgz",
+      "integrity": "sha512-Q3CsICOy3FuGZvWLTpbB0RDB3dVLiv2/1qWB49Rnedc0uPc0d6LtVZqmGZ6X+DUC7V3OdkMD/YWAmJlJnmoZFQ==",
       "dependencies": {
         "domhandler": "5.0.3",
         "htmlparser2": "9.0.0"
@@ -16073,9 +16073,9 @@
       }
     },
     "html-dom-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.1.tgz",
-      "integrity": "sha512-YADpM4AxP/W4Kyea3Aonmwz64pwlijbXpKHaNwd0ipK/OzCOamI0a24L6nh60uwHmcpD7wC3xvL9unWCPk7tiQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.0.tgz",
+      "integrity": "sha512-Q3CsICOy3FuGZvWLTpbB0RDB3dVLiv2/1qWB49Rnedc0uPc0d6LtVZqmGZ6X+DUC7V3OdkMD/YWAmJlJnmoZFQ==",
       "requires": {
         "domhandler": "5.0.3",
         "htmlparser2": "9.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "4.0.1",
+    "html-dom-parser": "5.0.0",
     "react-property": "2.0.0",
     "style-to-js": "1.1.4"
   },

--- a/test/dom-to-react.test.js
+++ b/test/dom-to-react.test.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const htmlToDOM = require('html-dom-parser');
+const htmlToDOM = require('html-dom-parser').default;
 
 const domToReact = require('../lib/dom-to-react');
 const utilities = require('../lib/utilities');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,9 +16,8 @@ describe('module', () => {
   });
 
   it('exports htmlToDOM', () => {
-    expect(parse.htmlToDOM).toBe(require('html-dom-parser'));
+    expect(parse.htmlToDOM).toBe(require('html-dom-parser').default);
     expect(parse.htmlToDOM).toBeInstanceOf(Function);
-    expect(parse.htmlToDOM.default).toBe(parse.htmlToDOM);
   });
 
   it('exports attributesToProps', () => {


### PR DESCRIPTION
Release-As: 4.2.4

## What is the motivation for this pull request?

build(package): bump html-dom-parser from 4.0.1 to 5.0.0

## What is the current behavior?

[html-dom-parser v4.0.1](https://github.com/remarkablemark/html-dom-parser/releases/tag/v4.0.1)

## What is the new behavior?

[html-dom-parser v5.0.0](https://github.com/remarkablemark/html-dom-parser/releases/tag/v5.0.0)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types