### PR TITLE
fix: upgrade `html-dom-parser` and `style-to-js` to fix source map warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "5.0.1",
+        "html-dom-parser": "5.0.2",
         "react-property": "2.0.0",
-        "style-to-js": "1.1.6"
+        "style-to-js": "1.1.8"
       },
       "devDependencies": {
         "@commitlint/cli": "17.8.0",
@@ -6164,9 +6164,9 @@
       "license": "ISC"
     },
     "node_modules/html-dom-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.1.tgz",
-      "integrity": "sha512-8MRxHcUjkpfkCEvf3t+r1nO7KCHgfFah23tAskZHgiOFsP5/24uxJnoS6C2Hq+p/cAzpPUiKb8vjywH6ixEgzQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.2.tgz",
+      "integrity": "sha512-TPsxRbmzLQP4umvzRnI3US/DuqoHTX3QOGTsH9pNST6z1tm/ZOP4eWRqvGrv6rvOX42QRPF6opbOBoHM2UfTFQ==",
       "dependencies": {
         "domhandler": "5.0.3",
         "htmlparser2": "9.0.0"
@@ -10168,17 +10168,17 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.6.tgz",
-      "integrity": "sha512-8cx8YkokAgEqGMGhoVI2pdeiVBwPUk0ZhaF/YLsvm64EIVMN4LaiJ7eqkiboD5WnAX/11z3IMMxzxsBBbdCTow==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.8.tgz",
+      "integrity": "sha512-bPSspCXkkhETLXnEgDbaoWRWyv3lF2bj32YIc8IElok2IIMHUlZtQUrxYmAkKUNxpluhH0qnKWrmuoXUyTY12g==",
       "dependencies": {
-        "style-to-object": "1.0.1"
+        "style-to-object": "1.0.3"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.1.tgz",
-      "integrity": "sha512-Mp9eBDx0knTrUGKyImO1enNWkOEYMAr/ut8SUYtPpOFOu5+HOR0yMF4pnExOklQvdSlxh+Mi0+6hUZVBb1zdRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.3.tgz",
+      "integrity": "sha512-xOpx7S53E0V3DpVsvt7ySvoiumRpfXiC99PUXLqGB3wiAnN9ybEIpuzlZ8LAZg+h1sl9JkEUwtSQXxcCgFqbbg==",
       "dependencies": {
         "inline-style-parser": "0.2.2"
       }
@@ -16073,9 +16073,9 @@
       }
     },
     "html-dom-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.1.tgz",
-      "integrity": "sha512-8MRxHcUjkpfkCEvf3t+r1nO7KCHgfFah23tAskZHgiOFsP5/24uxJnoS6C2Hq+p/cAzpPUiKb8vjywH6ixEgzQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.2.tgz",
+      "integrity": "sha512-TPsxRbmzLQP4umvzRnI3US/DuqoHTX3QOGTsH9pNST6z1tm/ZOP4eWRqvGrv6rvOX42QRPF6opbOBoHM2UfTFQ==",
       "requires": {
         "domhandler": "5.0.3",
         "htmlparser2": "9.0.0"
@@ -18806,17 +18806,17 @@
       "dev": true
     },
     "style-to-js": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.6.tgz",
-      "integrity": "sha512-8cx8YkokAgEqGMGhoVI2pdeiVBwPUk0ZhaF/YLsvm64EIVMN4LaiJ7eqkiboD5WnAX/11z3IMMxzxsBBbdCTow==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.8.tgz",
+      "integrity": "sha512-bPSspCXkkhETLXnEgDbaoWRWyv3lF2bj32YIc8IElok2IIMHUlZtQUrxYmAkKUNxpluhH0qnKWrmuoXUyTY12g==",
       "requires": {
-        "style-to-object": "1.0.1"
+        "style-to-object": "1.0.3"
       }
     },
     "style-to-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.1.tgz",
-      "integrity": "sha512-Mp9eBDx0knTrUGKyImO1enNWkOEYMAr/ut8SUYtPpOFOu5+HOR0yMF4pnExOklQvdSlxh+Mi0+6hUZVBb1zdRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.3.tgz",
+      "integrity": "sha512-xOpx7S53E0V3DpVsvt7ySvoiumRpfXiC99PUXLqGB3wiAnN9ybEIpuzlZ8LAZg+h1sl9JkEUwtSQXxcCgFqbbg==",
       "requires": {
         "inline-style-parser": "0.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "5.0.1",
+    "html-dom-parser": "5.0.2",
     "react-property": "2.0.0",
-    "style-to-js": "1.1.6"
+    "style-to-js": "1.1.8"
   },
   "devDependencies": {
     "@commitlint/cli": "17.8.0",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: upgrade html-dom-parser and style-to-js to fix source map warnings

Fixes #1097

```
 html-dom-parser  5.0.1  →  5.0.2
 style-to-js      1.1.6  →  1.1.8
```

## What is the current behavior?

Source map warnings

## What is the new behavior?

No source map warnings

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types