### PR TITLE
chore(utilities): remove unused function `invertObject`

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,41 +1,6 @@
 var React = require('react');
 var styleToJS = require('style-to-js').default;
 
-/**
- * Swap key with value in an object.
- *
- * @param {object} obj - The object.
- * @param {Function} [override] - The override method.
- * @returns - The inverted object.
- */
-function invertObject(obj, override) {
-  if (!obj || typeof obj !== 'object') {
-    throw new TypeError('First argument must be an object');
-  }
-
-  var isOverridePresent = typeof override === 'function';
-  var overrides = {};
-  var result = {};
-
-  for (var key in obj) {
-    var value = obj[key];
-
-    if (isOverridePresent) {
-      overrides = override(key, value);
-      if (overrides && overrides.length === 2) {
-        result[overrides[0]] = overrides[1];
-        continue;
-      }
-    }
-
-    if (typeof value === 'string') {
-      result[value] = key;
-    }
-  }
-
-  return result;
-}
-
 var RESERVED_SVG_MATHML_ELEMENTS = new Set([
   'annotation-xml',
   'color-profile',
@@ -133,7 +98,6 @@ function returnFirstArg(arg) {
 module.exports = {
   PRESERVE_CUSTOM_ATTRIBUTES: PRESERVE_CUSTOM_ATTRIBUTES,
   ELEMENTS_WITH_NO_TEXT_CHILDREN: ELEMENTS_WITH_NO_TEXT_CHILDREN,
-  invertObject: invertObject,
   isCustomComponent: isCustomComponent,
   setStyleProp: setStyleProp,
   canTextBeChildOfNode: canTextBeChildOfNode,

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -2,73 +2,10 @@ const React = require('react');
 const {
   PRESERVE_CUSTOM_ATTRIBUTES,
   ELEMENTS_WITH_NO_TEXT_CHILDREN,
-  invertObject,
   isCustomComponent,
   setStyleProp,
   canTextBeChildOfNode
 } = require('../lib/utilities');
-
-describe('invertObject', () => {
-  it.each([undefined, null, '', 'test', 0, 1, true, false, () => {}])(
-    'throws error for value: %p',
-    (value) => {
-      expect(() => {
-        invertObject(value);
-      }).toThrow(TypeError);
-    }
-  );
-
-  it('swaps key with value', () => {
-    expect(
-      invertObject({
-        foo: 'bar',
-        baz: 'qux'
-      })
-    ).toEqual({
-      bar: 'foo',
-      qux: 'baz'
-    });
-  });
-
-  it('swaps key with value if value is string', () => {
-    expect(
-      invertObject({
-        $: 'dollar',
-        _: 'underscore',
-        num: 1,
-        u: undefined,
-        n: null
-      })
-    ).toEqual({
-      dollar: '$',
-      underscore: '_'
-    });
-  });
-
-  describe('options', () => {
-    it('applies override if provided', () => {
-      expect(
-        invertObject({ foo: 'bar', baz: 'qux' }, (key) => {
-          if (key === 'foo') {
-            return ['key', 'value'];
-          }
-        })
-      ).toEqual({ key: 'value', qux: 'baz' });
-    });
-
-    it('does not apply override if invalid', () => {
-      expect(
-        invertObject({ foo: 'bar', baz: 'qux' }, (key) => {
-          if (key === 'foo') {
-            return ['key'];
-          } else if (key === 'baz') {
-            return { key: 'value' };
-          }
-        })
-      ).toEqual({ bar: 'foo', qux: 'baz' });
-    });
-  });
-});
 
 describe('isCustomComponent', () => {
   it('returns true if the tag contains a hyphen and is not in the whitelist', () => {


### PR DESCRIPTION
## What is the motivation for this pull request?

chore(utilities): remove unused function `invertObject`

Release-As: 4.2.8

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types