### PR TITLE
build(package): bump `react-property` from 2.0.0 to 2.0.2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 5.0
+// TypeScript Version: 5.3
 /* eslint-disable no-undef, no-unused-vars */
 
 import {

--- a/lib/attributes-to-props.d.ts
+++ b/lib/attributes-to-props.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 5.0
+// TypeScript Version: 5.3
 /* eslint-disable no-unused-vars */
 
 export type Attributes = Record<string, string>;

--- a/lib/dom-to-react.d.ts
+++ b/lib/dom-to-react.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 5.0
+// TypeScript Version: 5.3
 /* eslint-disable no-undef, no-unused-vars */
 
 import { DOMNode, HTMLReactParserOptions } from '..';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "domhandler": "5.0.3",
         "html-dom-parser": "5.0.2",
-        "react-property": "2.0.0",
+        "react-property": "2.0.2",
         "style-to-js": "1.1.8"
       },
       "devDependencies": {
@@ -9264,8 +9264,9 @@
       "dev": true
     },
     "node_modules/react-property": {
-      "version": "2.0.0",
-      "license": "MIT"
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -18392,7 +18393,9 @@
       "dev": true
     },
     "react-property": {
-      "version": "2.0.0"
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "domhandler": "5.0.3",
     "html-dom-parser": "5.0.2",
-    "react-property": "2.0.0",
+    "react-property": "2.0.2",
     "style-to-js": "1.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## What is the motivation for this pull request?

Release-As: 4.2.9

```
 react-property   2.0.0  →  2.0.2
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Types