### PR TITLE
fix(dom-to-react): default props.children to `undefined` instead of `null`

### DIFF
--- a/__tests__/dom-to-react.test.tsx
+++ b/__tests__/dom-to-react.test.tsx
@@ -84,7 +84,7 @@ describe('domToReact', () => {
 
   it('does not have `children` for void elements', () => {
     const reactElement = domToReact(htmlToDOM(html.img)) as JSX.Element;
-    expect(reactElement.props.children).toBe(null);
+    expect(reactElement.props.children).toBe(undefined);
   });
 
   it('does not throw an error for void elements', () => {

--- a/src/dom-to-react.ts
+++ b/src/dom-to-react.ts
@@ -96,7 +96,7 @@ export default function domToReact(
       props = attributesToProps(element.attribs, element.name);
     }
 
-    let children = null;
+    let children;
 
     switch (node.type) {
       case 'script':


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(dom-to-react): default props.children to undefined instead of null

## What is the current behavior?

props.children defaults to `null`. E.g., `parse('<br>')`:

```js
{
  '$$typeof': Symbol(react.element),
  type: 'br',
  key: null,
  ref: null,
  props: { children: null },
  _owner: null,
  _store: {}
}
```

## What is the new behavior?

props.children defaults to `undefined`

This ensures the parsed element is consistent with the React element `<br >`:

```js
{
  '$$typeof': Symbol(react.element),
  type: 'br',
  key: null,
  ref: null,
  props: {},
  _owner: null,
  _store: {}
}
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation