### PR TITLE
fix(types): add back `object` to `replace` option return type

### DIFF
--- a/__tests__/dom-to-react.test.tsx
+++ b/__tests__/dom-to-react.test.tsx
@@ -172,6 +172,16 @@ describe('library option', () => {
 });
 
 describe('replace option', () => {
+  it.each([undefined, null, 0, 1, true, false, {}])(
+    'does not replace for invalid return value %p',
+    (value) => {
+      const reactElement = domToReact(htmlToDOM('<br>'), {
+        replace: () => value,
+      }) as JSX.Element;
+      expect(reactElement).toEqual(<br />);
+    },
+  );
+
   it("does not set key if there's a single node", () => {
     const reactElement = domToReact(htmlToDOM(html.single), {
       replace: () => <div />,
@@ -213,17 +223,12 @@ describe('replace option', () => {
     const options: HTMLReactParserOptions = {
       replace(domNode) {
         if (domNode instanceof Element) {
-          return <>{domToReact(domNode.children as DOMNode[], options)}</>;
+          return domToReact(domNode.children as DOMNode[], options);
         }
       },
     };
-
-    const reactElement = domToReact(
-      htmlToDOM(html.single),
-      options,
-    ) as JSX.Element;
-
-    expect(reactElement).toBeInstanceOf(Object);
+    const reactElement = domToReact(htmlToDOM('<div>test</div>'), options);
+    expect(reactElement).toEqual(<div>test</div>);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,9 @@ export interface HTMLReactParserOptions {
     [key: string]: any;
   };
 
-  replace?: (domNode: DOMNode) => JSX.Element | string | null | boolean | void;
+  replace?: (
+    domNode: DOMNode,
+  ) => JSX.Element | string | null | boolean | object | void;
 
   transform?: (
     reactNode: ReactNode,


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(types): add back `object` to `replace` option return type

Maintains backward compatibility for invalid return type

Fixes #1126

## What is the current behavior?

Removed `object` return type from `replace` option in v5

## What is the new behavior?

Revert removal of `object` return type from `replace` option

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation