### PR TITLE
fix(esm): support vite bundler

### DIFF
--- a/esm/attributes-to-props.mjs
+++ b/esm/attributes-to-props.mjs
@@ -1,3 +1,3 @@
 import attributesToProps from '../lib/attributes-to-props.js';
 
-export default attributesToProps.default;
+export default attributesToProps.default || attributesToProps;

--- a/esm/dom-to-react.mjs
+++ b/esm/dom-to-react.mjs
@@ -1,3 +1,3 @@
 import domToReact from '../lib/dom-to-react.js';
 
-export default domToReact.default;
+export default domToReact.default || domToReact;

--- a/esm/index.mjs
+++ b/esm/index.mjs
@@ -10,4 +10,4 @@ export {
   htmlToDOM,
 } from '../lib/index.js';
 
-export default HTMLReactParser.default;
+export default HTMLReactParser.default || HTMLReactParser;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(esm): support vite bundler

Fixes #1132

## What is the current behavior?

Running `npx vite build && npx vite preview` throws an error in the browser:

```
TypeError: rm is not a function
```

## What is the new behavior?

Fix the default export so that vite builds properly

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation