### PR TITLE
docs(readme): modify contributors img in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ npx size-limit
 
 This project exists thanks to all the people who contribute. [[Contribute](https://github.com/remarkablemark/html-react-parser/blob/master/.github/CONTRIBUTING.md)].
 
-[![Code Contributors](https://opencollective.com/html-react-parser/contributors.svg?width=890&button=false)](https://github.com/remarkablemark/html-react-parser/graphs/contributors)
+[![Code Contributors](https://contrib.rocks/image?repo=remarkablemark/html-react-parser)](https://github.com/remarkablemark/html-react-parser/graphs/contributors)
 
 ### Financial Contributors
 


### PR DESCRIPTION

## What is the motivation for this pull request?

@remarkablemark 
I'm very happy to contribute to that library! Thanks again for providing such a great library 🤗

How about changing `Contributors` in the `README.md` from `opencollective` to [contrib.rocks](https://contrib.rocks/preview?repo=angular%2Fangular-ja) since it doesn't seem to be up to date? 😂 

## to-be
![스크린샷 2023-11-03 오전 1 49 03](https://github.com/remarkablemark/html-react-parser/assets/64779472/9527229f-72e5-476d-8bd0-54d4d3132447)

<br />

You can use the `max` and `columns` options if you need to!

```
https://contrib.rocks/image?repo=remarkablemark/html-react-parser&max=10&columns=10
```

![스크린샷 2023-11-03 오전 1 54 37](https://github.com/remarkablemark/html-react-parser/assets/64779472/184e9d81-adf0-4397-b814-f98f65905698)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
