### PR TITLE
fix(esm): make ESM exports explicit in index.mjs and utilities.mjs

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -2,6 +2,7 @@
   "extends": ["@commitlint/config-conventional"],
   "rules": {
     "body-max-line-length": [1, "always", 100],
+    "footer-max-line-length": [1, "always", 100],
     "type-empty": [2, "never"]
   }
 }

--- a/esm/index.mjs
+++ b/esm/index.mjs
@@ -1,5 +1,13 @@
 import HTMLReactParser from '../lib/index.js';
 
-export * from '../lib/index.js';
+export {
+  Comment,
+  Element,
+  ProcessingInstruction,
+  Text,
+  attributesToProps,
+  domToReact,
+  htmlToDOM,
+} from '../lib/index.js';
 
 export default HTMLReactParser.default || HTMLReactParser;

--- a/esm/utilities.mjs
+++ b/esm/utilities.mjs
@@ -1,1 +1,8 @@
-export * from '../lib/utilities.js';
+export {
+  isCustomComponent,
+  setStyleProp,
+  PRESERVE_CUSTOM_ATTRIBUTES,
+  ELEMENTS_WITH_NO_TEXT_CHILDREN,
+  canTextBeChildOfNode,
+  returnFirstArg,
+} from '../lib/utilities.js';


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #1228

Caused by #1226

## What is the current behavior?

Vite fails with the error:

```
Uncaught SyntaxError: The requested module '/@fs/Users/.../node_modules/.vite/app/deps/html-react-parser.js?v=719515aa' does not provide an export named 'Element' (at list.tsx:6:31)
```

`*` exports in ESM files

## What is the new behavior?

Vite does not error

Named exports in ESM files

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation