### PR TITLE
refactor: improved dom-to-react, type

### DIFF
--- a/src/dom-to-react.ts
+++ b/src/dom-to-react.ts
@@ -28,14 +28,14 @@ const React = {
  */
 export default function domToReact(
   nodes: DOMNode[],
-  options?: HTMLReactParserOptions,
+  options: HTMLReactParserOptions = {},
 ): string | JSX.Element | JSX.Element[] {
   const reactElements = [];
 
-  const hasReplace = typeof options?.replace === 'function';
-  const transform = options?.transform || returnFirstArg;
+  const hasReplace = typeof options.replace === 'function';
+  const transform = options.transform || returnFirstArg;
   const { cloneElement, createElement, isValidElement } =
-    options?.library || React;
+    options.library || React;
 
   const nodesLength = nodes.length;
 
@@ -75,7 +75,7 @@ export default function domToReact(
 
       // Trim is enabled and we have a whitespace node
       // so skip it
-      if (options?.trim && isWhitespace) {
+      if (options.trim && isWhitespace) {
         continue;
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,13 @@ export interface HTMLReactParserOptions {
     cloneElement: (
       element: JSX.Element,
       props?: object,
-      ...children: any
+      ...children: any[]
     ) => JSX.Element;
-    createElement: (type: any, props?: object, ...children: any) => JSX.Element;
+    createElement: (
+      type: any,
+      props?: object,
+      ...children: any[]
+    ) => JSX.Element;
     isValidElement: (element: any) => boolean;
     [key: string]: any;
   };


### PR DESCRIPTION
Release-As: 5.1.2
@remarkablemark  👋
## What is the motivation for this pull request?

```tsx
function attributesToProps(attributes?: Attributes, nodeName?: string): Props

export default function attributesToProps(
  attributes: Attributes = {},
  nodeName?: string,
)
```
What do you think about utilizing the same default parameters as `attributes`? 
We can remove optional chaining ..!! 

I think it's clearer to specify the type of `rest parameter` as an array. 

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
There is no change in behavior

## What is the new behavior?
There is no change in behavior 

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
