### PR TITLE
fix: move `@types/react` to dependencies and fix esm types

### DIFF
--- a/esm/attributes-to-props.d.mts
+++ b/esm/attributes-to-props.d.mts
@@ -1,1 +1,4 @@
-export { default } from '../lib/attributes-to-props';
+import attributesToProps from '../lib/attributes-to-props.js';
+
+// @ts-expect-error Property 'default' exists on type
+export default attributesToProps.default || attributesToProps;

--- a/esm/dom-to-react.d.mts
+++ b/esm/dom-to-react.d.mts
@@ -1,1 +1,4 @@
-export { default } from '../lib/dom-to-react';
+import domToReact from '../lib/dom-to-react.js';
+
+// @ts-expect-error Property 'default' exists on type
+export default domToReact.default || domToReact;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.1.4",
       "license": "MIT",
       "dependencies": {
+        "@types/react": "18.2.55",
         "domhandler": "5.0.3",
         "html-dom-parser": "5.0.8",
         "react-property": "2.0.2",
@@ -24,7 +25,6 @@
         "@size-limit/preset-big-lib": "11.0.2",
         "@types/benchmark": "2.1.5",
         "@types/jest": "29.5.12",
-        "@types/react": "18.2.55",
         "@types/react-dom": "18.2.19",
         "@typescript-eslint/eslint-plugin": "7.0.1",
         "@typescript-eslint/parser": "7.0.1",
@@ -2208,14 +2208,12 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.55",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
       "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2238,7 +2236,6 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -3657,7 +3654,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dargs": {
@@ -11458,14 +11454,12 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "dev": true
+      "version": "15.7.5"
     },
     "@types/react": {
       "version": "18.2.55",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
       "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11486,8 +11480,7 @@
       "dev": true
     },
     "@types/scheduler": {
-      "version": "0.16.3",
-      "dev": true
+      "version": "0.16.3"
     },
     "@types/semver": {
       "version": "7.5.7",
@@ -12470,8 +12463,7 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "dev": true
+      "version": "3.1.2"
     },
     "dargs": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dom"
   ],
   "dependencies": {
+    "@types/react": "18.2.55",
     "domhandler": "5.0.3",
     "html-dom-parser": "5.0.8",
     "react-property": "2.0.2",
@@ -63,7 +64,6 @@
     "@size-limit/preset-big-lib": "11.0.2",
     "@types/benchmark": "2.1.5",
     "@types/jest": "29.5.12",
-    "@types/react": "18.2.55",
     "@types/react-dom": "18.2.19",
     "@typescript-eslint/eslint-plugin": "7.0.1",
     "@typescript-eslint/parser": "7.0.1",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: move `@types/react` to dependencies and fix esm types

Fixes #1313

## What is the current behavior?

Default import has return type of `any`

## What is the new behavior?

Default import has valid return type

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation