### PR TITLE
fix(esm): fix any type

### DIFF
--- a/esm/index.d.mts
+++ b/esm/index.d.mts
@@ -2,5 +2,4 @@ import HTMLReactParser from '../lib/index.js';
 
 export * from '../lib/index.js';
 
-// @ts-expect-error Property 'default' exists on type
-export default HTMLReactParser.default || HTMLReactParser;
+export default (HTMLReactParser.default as typeof HTMLReactParser ?? HTMLReactParser);

--- a/esm/index.d.mts
+++ b/esm/index.d.mts
@@ -3,4 +3,5 @@ import HTMLReactParser from '../lib/index.js';
 export * from '../lib/index.js';
 
 // @ts-expect-error Property 'default' exists on type
-export default (HTMLReactParser.default as typeof HTMLReactParser ?? HTMLReactParser);
+export default (HTMLReactParser.default as typeof HTMLReactParser) ??
+  HTMLReactParser;

--- a/esm/index.d.mts
+++ b/esm/index.d.mts
@@ -2,4 +2,5 @@ import HTMLReactParser from '../lib/index.js';
 
 export * from '../lib/index.js';
 
+// @ts-expect-error Property 'default' exists on type
 export default (HTMLReactParser.default as typeof HTMLReactParser ?? HTMLReactParser);


### PR DESCRIPTION
Fix `any` type of export: 

<img width="476" alt="image" src="https://github.com/remarkablemark/html-react-parser/assets/1469266/be779da9-0ed0-4d53-81c2-7019e59855f7">

## What is the motivation for this pull request?

Import:
```typescript
import HTMLReactParser from 'html-react-parser';

HTMLReactParser('');
```
Results in `any` typed `HTMLReactParser` reference that is disallowed by linters in many projects:

```
Unsafe call of an `any` typed value.eslint[@typescript-eslint/no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call)
```

## What is the current behavior?

The export is not typed (i.e. `any`).

## What is the new behavior?

The export type is fixed to the expected one.

## Checklist:

- [ ] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation
