### PR TITLE
fix(package): set dependency `@types/react` to 17 or 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.6",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "18.2.55",
+        "@types/react": "17 || 18",
         "domhandler": "5.0.3",
         "html-dom-parser": "5.0.8",
         "react-property": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dom"
   ],
   "dependencies": {
-    "@types/react": "18.2.55",
+    "@types/react": "17 || 18",
     "domhandler": "5.0.3",
     "html-dom-parser": "5.0.8",
     "react-property": "2.0.2",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): set dependency `@types/react` to 17 or 18

Fixes #1320

## What is the current behavior?

`@types/react` is set to `18.2.55`

## What is the new behavior?

`@types/react` is set to `17 || 18`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation