### PR TITLE
build(package): make @types/react an optional peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.1.7",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "17 || 18",
         "domhandler": "5.0.3",
         "html-dom-parser": "5.0.8",
         "react-property": "2.0.2",
@@ -25,6 +24,7 @@
         "@size-limit/preset-big-lib": "11.0.2",
         "@types/benchmark": "2.1.5",
         "@types/jest": "29.5.12",
+        "@types/react": "18.2.59",
         "@types/react-dom": "18.2.19",
         "@typescript-eslint/eslint-plugin": "7.1.0",
         "@typescript-eslint/parser": "7.1.0",
@@ -45,7 +45,13 @@
         "typescript": "5.3.3"
       },
       "peerDependencies": {
+        "@types/react": "17 || 18",
         "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2208,12 +2214,14 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.59",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.59.tgz",
       "integrity": "sha512-DE+F6BYEC8VtajY85Qr7mmhTd/79rJKIHCg99MU9SWPB4xvLb6D1za2vYflgZfmPqQVEr6UqJTnLXEwzpVPuOg==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2236,6 +2244,7 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -3654,6 +3663,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dargs": {
@@ -11466,12 +11476,14 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.5"
+      "version": "15.7.5",
+      "dev": true
     },
     "@types/react": {
       "version": "18.2.59",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.59.tgz",
       "integrity": "sha512-DE+F6BYEC8VtajY85Qr7mmhTd/79rJKIHCg99MU9SWPB4xvLb6D1za2vYflgZfmPqQVEr6UqJTnLXEwzpVPuOg==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11492,7 +11504,8 @@
       "dev": true
     },
     "@types/scheduler": {
-      "version": "0.16.3"
+      "version": "0.16.3",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -12475,7 +12488,8 @@
       }
     },
     "csstype": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "dev": true
     },
     "dargs": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "dom"
   ],
   "dependencies": {
-    "@types/react": "17 || 18",
     "domhandler": "5.0.3",
     "html-dom-parser": "5.0.8",
     "react-property": "2.0.2",
@@ -64,6 +63,7 @@
     "@size-limit/preset-big-lib": "11.0.2",
     "@types/benchmark": "2.1.5",
     "@types/jest": "29.5.12",
+    "@types/react": "18.2.59",
     "@types/react-dom": "18.2.19",
     "@typescript-eslint/eslint-plugin": "7.1.0",
     "@typescript-eslint/parser": "7.1.0",
@@ -84,7 +84,13 @@
     "typescript": "5.3.3"
   },
   "peerDependencies": {
+    "@types/react": "17 || 18",
     "react": "0.14 || 15 || 16 || 17 || 18"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "files": [
     "/dist",


### PR DESCRIPTION
## What is the motivation for this pull request?

build(package): make `@types/react` an optional peerDependency

Release-As: 5.1.8

## What is the current behavior?

`@types/react` is a required dependency

## What is the new behavior?

`@types/react` is an optional peerDependency

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation