### PR TITLE
build(package): match allowed peer dependency ranges of react and @types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "5.5.3"
   },
   "peerDependencies": {
-    "@types/react": "17 || 18",
+    "@types/react": "0.14 || 15 || 16 || 17 || 18",
     "react": "0.14 || 15 || 16 || 17 || 18"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## What is the motivation for this pull request?

build(peer-deps): match allowed peer dependency ranges of `react` and `@types/react`

Fixes #1462

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation