### PR TITLE
fix: bump up html-dom-parser to handle carriage return

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "domhandler": "5.0.3",
-    "html-dom-parser": "5.0.10",
+    "html-dom-parser": "5.0.11",
     "react-property": "2.0.2",
     "style-to-js": "1.1.16"
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix

## What is the current behavior?

Addresses [html-dom-parser #420](https://github.com/remarkablemark/html-dom-parser/issues/420)
Fixes #864

## What is the new behavior?

```js
const text = "toto \r\n toto"

parse(text)

old output: "toto toto"
new output: "toto \r\n toto"
```

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests

