### PR TITLE
Fix exported DOM Element instanceof checks

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -123,6 +123,27 @@ describe('HTMLReactParser', () => {
 });
 
 describe('replace option', () => {
+  it('provides DOM elements that are instances of the exported Element', () => {
+    const checks: boolean[] = [];
+
+    parse('<p>Hello <strong>world</strong></p><br />', {
+      replace(domNode) {
+        if (
+          domNode instanceof HTMLReactParser.Element &&
+          domNode.name === 'p'
+        ) {
+          const [text, strong] = domNode.children;
+
+          checks.push(domhandler.isText(text));
+          checks.push(strong instanceof HTMLReactParser.Element);
+          checks.push(domNode.next instanceof HTMLReactParser.Element);
+        }
+      },
+    });
+
+    expect(checks).toEqual([true, true, true]);
+  });
+
   it('replaces the element if a valid React element is returned', () => {
     expect(
       parse(html.complex, {

--- a/src/dom-to-react.ts
+++ b/src/dom-to-react.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 
+import { Element as DomHandlerElement } from 'domhandler';
 import type { DOMNode, Element, Text } from 'html-dom-parser';
 import type { JSX } from 'react';
 import { cloneElement, createElement, isValidElement } from 'react';
@@ -40,6 +41,8 @@ export default function domToReact(
     options.library ?? React;
 
   const nodesLength = nodes.length;
+
+  normalizeDOMNodes(nodes);
 
   for (let index = 0; index < nodesLength; index++) {
     const node = nodes[index];
@@ -148,6 +151,19 @@ export default function domToReact(
   }
 
   return reactElements.length === 1 ? reactElements[0] : reactElements;
+}
+
+function normalizeDOMNodes(nodes: DOMNode[]): void {
+  for (const node of nodes) {
+    if (
+      node.type === 'tag' ||
+      node.type === 'script' ||
+      node.type === 'style'
+    ) {
+      Object.setPrototypeOf(node, DomHandlerElement.prototype);
+      normalizeDOMNodes(node.children as DOMNode[]);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes `instanceof` checks for DOM elements passed to the `replace` callback.

## What changed

- Added a regression test for exported `Element` instances in `replace`.
- Normalized parser-created DOM element prototypes to the `Element` class exported by this package.

## Why

`html-dom-parser` can create DOM element instances whose class reference differs from the `Element` class exported by `html-react-parser`. That breaks documented checks like `domNode instanceof Element`.

## Testing

- `npm run prepublishOnly`
- `npm run test:esm`
- `npm run test:browser`

Fixes #2198