### PR TITLE
ci(github): add UMD page test to workflow test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ permissions: read-all
 jobs:
   unit:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -39,7 +38,6 @@ jobs:
     strategy:
       matrix:
         browser: [chromium, firefox, webkit]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -58,3 +56,28 @@ jobs:
 
       - name: Run browser tests on ${{ matrix.browser }}
         run: npm test -- --config=vitest.config.browser.mts --browser=${{ matrix.browser }}
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Build package
+        run: npm run build
+
+      - name: Test UMD page
+        uses: remarkablemark/page-test-action@501177ce8d124eff6bc5e7b930a3dbd62f28a173 # v1.0.6
+        with:
+          url: http://localhost:8000/examples/script
+          start: python3 -m http.server
+          wait-on: http://localhost:8000

--- a/src/attributes-to-props.ts
+++ b/src/attributes-to-props.ts
@@ -67,8 +67,7 @@ export default function attributesToProps(
 
     if (propName) {
       const propertyInfo = getPropertyInfo(propName) as
-        | { type: number }
-        | undefined;
+        { type: number } | undefined;
 
       // convert attribute to uncontrolled component prop (e.g., `value` to `defaultValue`)
       if (


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): add UMD page test to workflow test.yml

## What is the new behavior?

- Add `page-test-action` step to test the UMD example page
- Start a local Python HTTP server on port 8000
- Navigate to `http://localhost:8000/examples/script` and check for errors

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation