### PR TITLE
fix: bump html-dom-parser@8.0.2 so require does not throw ERR_REQUIRE_ESM_RACE_CONDITION

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "6.0.1",
-        "html-dom-parser": "8.0.1",
+        "html-dom-parser": "8.0.2",
         "react-property": "2.0.2",
         "style-to-js": "2.0.2"
       },
@@ -4964,9 +4964,9 @@
       }
     },
     "node_modules/html-dom-parser": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-8.0.1.tgz",
-      "integrity": "sha512-OnbsHX7WBOOoSroBMm936nbUIcHzDIQdKqKRLgOSI8dNNBIVVq3CYYNKhVv0csmP623jJcSNfA+gUENTR7HVWA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-8.0.2.tgz",
+      "integrity": "sha512-UnUW0rcyfkYo9OCgeo+5Pzc4lRaifZB4h8RlGRwYIJmEz97Q3OKIYhNVXhG53jmNKWvBrq9n4ZzZIZAECnatSw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   ],
   "dependencies": {
     "domhandler": "6.0.1",
-    "html-dom-parser": "8.0.1",
+    "html-dom-parser": "8.0.2",
     "react-property": "2.0.2",
     "style-to-js": "2.0.2"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
-import type { DomHandlerOptions } from 'domhandler';
-import type { DOMNode, TrustedTypePolicy } from 'html-dom-parser';
-import type { ParserOptions } from 'htmlparser2';
+import type {
+  DOMNode,
+  HTMLDOMParserOptions,
+  TrustedTypePolicy,
+} from 'html-dom-parser';
 import type { JSX, ReactNode } from 'react';
 
 export interface HTMLReactParserOptions {
-  htmlparser2?: ParserOptions & DomHandlerOptions;
+  htmlparser2?: Omit<HTMLDOMParserOptions, 'trustedTypePolicy'>;
   trustedTypePolicy?: TrustedTypePolicy;
 
   library?: {


### PR DESCRIPTION
## What is the motivation for this pull request?

Upgrade `html-dom-parser` from `8.0.1` to `8.0.2` so CJS require does not throw `ERR_REQUIRE_ESM_RACE_CONDITION` in Node.js 24+

See https://github.com/remarkablemark/html-dom-parser/issues/1551

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation